### PR TITLE
Add reduction history and live reduction pages specific to each instrument

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,10 @@ const App: FC = () => (
       <Route exact path="/">
         <Instrument />
       </Route>
-      <Route path="/live-reduction">
+      <Route path="/:instrumentName/live_reduction">
         <LiveReduction />
       </Route>
-      <Route path="/reduction-history">
+      <Route path="/:instrumentName/reduction_history">
         <ReductionHistory />
       </Route>
     </Switch>

--- a/src/Instrument.tsx
+++ b/src/Instrument.tsx
@@ -130,7 +130,7 @@ const Instrument: React.FC = () => {
                     <Button
                       variant="contained"
                       component={RouterLink}
-                      to="/live-reduction"
+                      to={`/${instrument.name.toLowerCase()}/live_reduction`}
                       style={styles.button}
                     >
                       Live Reduction
@@ -138,7 +138,7 @@ const Instrument: React.FC = () => {
                     <Button
                       variant="contained"
                       component={RouterLink}
-                      to="/reduction-history"
+                      to={`/${instrument.name.toLowerCase()}/reduction_history`}
                       style={styles.secondButton}
                     >
                       Reduction History

--- a/src/LiveReduction.tsx
+++ b/src/LiveReduction.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
+import { useParams } from 'react-router-dom';
 
 const LiveReduction: React.FC = () => {
+  const { instrumentName } = useParams<{ instrumentName: string }>();
+
   return (
     <div>
-      <h1>Live Reduction Page</h1>
+      <h1>
+        {instrumentName
+          ? `${instrumentName.toUpperCase()} Live Reduction Page`
+          : 'Live Reduction Page'}
+      </h1>
       <p>This is the live reduction page. Content will be added soon.</p>
     </div>
   );

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
+import { useParams } from 'react-router-dom';
 
 const ReductionHistory: React.FC = () => {
+  const { instrumentName } = useParams<{ instrumentName: string }>();
+
   return (
     <div>
-      <h1>Reduction History Page</h1>
+      <h1>
+        {instrumentName
+          ? `${instrumentName.toUpperCase()} Reduction History Page`
+          : 'Reduction History Page'}
+      </h1>
       <p>This is the reduction history page. Content will be added soon.</p>
     </div>
   );


### PR DESCRIPTION
Closes #22.

How to test:

When on the instruments page, the buttons on the cards should lead to URLs for the corresponding instrument. For example, the ALF instrument should lead to URLs that say:

ir/alf/reduction_history
ir/alf/live_reduction