### PR TITLE
Allow instruments cards to be expanded when clicked anywhere

### DIFF
--- a/src/Instrument.tsx
+++ b/src/Instrument.tsx
@@ -70,7 +70,7 @@ const Instrument: React.FC = () => {
   };
 
   return (
-    <>
+    <Box sx={{ paddingBottom: '2rem' }}>
       <TableHead>
         <TableRow>
           <TableCell>
@@ -187,7 +187,7 @@ const Instrument: React.FC = () => {
           </Box>
         )
       )}
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Closes #30, closes #31.

Allow instruments cards to be expanded when clicked anywhere.

Add "Dr." prefix to scientist names.

## How to test:
Build and run the plugin. Clicking anywhere within an instrument card should cause it to expand / contract rather than just clicking the chevron like before.
