### PR TITLE
Add collapsible table logic

### DIFF
--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -212,18 +212,17 @@ const ReductionHistory: React.FC = () => {
                   </TableCell>
                   <TableCell
                     style={{ ...headerStyles, width: '15%' }}
-                    sortDirection={orderBy === 'reduction_start' ? orderDirection : false}
-                    onClick={() => handleSort('reduction_start')}
+                    sortDirection={orderBy === 'run_start' ? orderDirection : false}
+                    onClick={() => handleSort('run_start')}
                   >
-                    Reduction start {orderBy === 'reduction_start' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
+                    Run start {orderBy === 'run_start' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
                   <TableCell
                     style={{ ...headerStyles, width: '15%' }}
-                    sortDirection={orderBy === 'reduction_end' ? orderDirection : false}
-                    onClick={() => handleSort('reduction_end')}
+                    sortDirection={orderBy === 'run_end' ? orderDirection : false}
+                    onClick={() => handleSort('run_end')}
                   >
-                    Reduction end {orderBy === 'reduction_end' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
-                  </TableCell>
+                    Run end {orderBy === 'run_end' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
                   {/* API doesn't allow for sorting by title */}
                   <TableCell style={{ ...headerStyles, width: '40%' }}>Title</TableCell>
@@ -403,8 +402,8 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
           {reduction.runs[0].experiment_number}
         </TableCell>
         <TableCell>{extractFileName(reduction.runs[0].filename)}</TableCell>
-        <TableCell>{formatDateTime(reduction.reduction_start)}</TableCell>
-        <TableCell>{formatDateTime(reduction.reduction_end)}</TableCell>
+        <TableCell>{formatDateTime(reduction.runs[0].run_start)}</TableCell>
+        <TableCell>{formatDateTime(reduction.runs[0].run_end)}</TableCell>
         <TableCell>{reduction.runs[0].title}</TableCell>
       </TableRow>
       <TableRow sx={rowStyles}>
@@ -436,10 +435,10 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                     Instrument: {reduction.runs[0].instrument_name}
                   </Typography>
                   <Typography variant="body2" gutterBottom>
-                    Start: {formatDateTime(reduction.runs[0].run_start)}
+                    Reduction start: {formatDateTime(reduction.reduction_start)}
                   </Typography>
                   <Typography variant="body2" gutterBottom>
-                    End: {formatDateTime(reduction.runs[0].run_end)}
+                    Reduction end: {formatDateTime(reduction.reduction_start)}
                   </Typography>
                   <Typography variant="body2" gutterBottom>
                     Good frames: {reduction.runs[0].good_frames.toLocaleString()}

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -193,11 +193,11 @@ const ReductionHistory: React.FC = () => {
             <Table aria-label="collapsible table" stickyHeader>
               <TableHead>
                 <TableRow>
-                  <TableCell style={{ ...headerStyles, width: '10%' }} colSpan={2}>
+                  <TableCell style={{ ...headerStyles, width: '8%' }} colSpan={2}>
                     {selectedInstrument}
                   </TableCell>
                   <TableCell
-                    style={{ ...headerStyles, width: '10%' }}
+                    style={{ ...headerStyles, width: '12%' }}
                     sortDirection={orderBy === 'experiment_number' ? orderDirection : false}
                     onClick={() => handleSort('experiment_number')}
                   >

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -469,7 +469,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                     Reduction inputs
                   </Typography>
                   <Box sx={{ maxHeight: 140, overflowY: 'auto', marginBottom: 2 }}>{renderReductionInputs()}</Box>
-                  <Box>
+                  <Box display="flex" justifyContent="right">
                     <Tooltip title="Will be added in the future">
                       <span>
                         {/* Span is necessary because tooltip doesn't work directly on disabled elements */}

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -77,9 +77,7 @@ const ReductionHistory: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(0); // Page index starts at 0 for TablePagination
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [totalRows, setTotalRows] = useState(0);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [orderBy, setOrderBy] = useState<string>('run_start');
 
   useEffect(() => {

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -340,8 +340,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
     if (reduction.reduction_state === 'ERROR') {
       return (
         <Typography variant="subtitle1" style={{ color: 'red', fontWeight: 'bold' }}>
-          [ERROR] {reduction.reduction_status_message}: src\ReductionHistory.tsx Line 206:25: Missing return type on
-          function @typescript-eslint/explicit-function-return-type
+          [ERROR] {reduction.reduction_status_message}
         </Typography>
       );
     } else if (reduction.reduction_state === 'SUCCESSFUL') {

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -195,32 +195,32 @@ const ReductionHistory: React.FC = () => {
             <Table aria-label="collapsible table" stickyHeader>
               <TableHead>
                 <TableRow>
-                  <TableCell style={headerStyles} colSpan={2}>
+                  <TableCell style={{ ...headerStyles, width: '10%' }} colSpan={2}>
                     {selectedInstrument}
                   </TableCell>
                   <TableCell
-                    style={headerStyles}
+                    style={{ ...headerStyles, width: '10%' }}
                     sortDirection={orderBy === 'experiment_number' ? orderDirection : false}
                     onClick={() => handleSort('experiment_number')}
                   >
                     Experiment Number {orderBy === 'experiment_number' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
                   <TableCell
-                    style={headerStyles}
+                    style={{ ...headerStyles, width: '10%' }}
                     sortDirection={orderBy === 'filename' ? orderDirection : false}
                     onClick={() => handleSort('filename')}
                   >
                     Filename {orderBy === 'filename' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
                   <TableCell
-                    style={headerStyles}
+                    style={{ ...headerStyles, width: '15%' }}
                     sortDirection={orderBy === 'reduction_start' ? orderDirection : false}
                     onClick={() => handleSort('reduction_start')}
                   >
                     Reduction start {orderBy === 'reduction_start' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
                   <TableCell
-                    style={headerStyles}
+                    style={{ ...headerStyles, width: '15%' }}
                     sortDirection={orderBy === 'reduction_end' ? orderDirection : false}
                     onClick={() => handleSort('reduction_end')}
                   >
@@ -228,7 +228,7 @@ const ReductionHistory: React.FC = () => {
                   </TableCell>
                   {/* API currently doesn't allow for sorting by title so will crash the web app */}
                   <TableCell
-                    style={headerStyles}
+                    style={{ ...headerStyles, width: '40%' }}
                     sortDirection={orderBy === 'title' ? orderDirection : false}
                     onClick={() => handleSort('title')}
                   >
@@ -354,6 +354,12 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
       return (
         <Typography variant="subtitle1" style={{ color: 'gray', fontWeight: 'bold' }}>
           [NOT STARTED] This reduction has not been started yet
+        </Typography>
+      );
+    } else if (reduction.reduction_state === 'UNSUCCESSFUL') {
+      return (
+        <Typography variant="subtitle1" style={{ color: '#ed6c02', fontWeight: 'bold' }}>
+          [NOT STARTED] {reduction.reduction_status_message}
         </Typography>
       );
     } else {

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -224,14 +224,9 @@ const ReductionHistory: React.FC = () => {
                   >
                     Reduction end {orderBy === 'reduction_end' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
-                  {/* API currently doesn't allow for sorting by title so will crash the web app */}
-                  <TableCell
-                    style={{ ...headerStyles, width: '40%' }}
-                    sortDirection={orderBy === 'title' ? orderDirection : false}
-                    onClick={() => handleSort('title')}
-                  >
-                    Title {orderBy === 'title' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
                   </TableCell>
+                  {/* API doesn't allow for sorting by title */}
+                  <TableCell style={{ ...headerStyles, width: '40%' }}>Title</TableCell>
                 </TableRow>
               </TableHead>
 

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -300,9 +300,14 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                   {output}
                 </Box>
                 <Box>
-                  <Button variant="contained" style={{ marginLeft: '10px' }}>
-                    View
-                  </Button>
+                  <Tooltip title="Will be added in the future">
+                    <span>
+                      {/* Span is necessary because Tooltip doesn't work directly on disabled elements */}
+                      <Button variant="contained" style={{ marginLeft: '10px' }} disabled>
+                        View
+                      </Button>
+                    </span>
+                  </Tooltip>
                   <Tooltip title="Will be added in the future">
                     <span>
                       {/* Span is necessary because Tooltip doesn't work directly on disabled elements */}

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -145,7 +145,7 @@ const ReductionHistory: React.FC = () => {
   };
 
   const headerStyles = {
-    color: 'white',
+    color: theme.palette.primary.contrastText,
     backgroundColor: theme.palette.primary.main,
     fontWeight: 'bold',
     borderRight: `1px solid #1f4996`,

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -295,7 +295,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
         return parsed.map((output, index: number) => (
           <TableRow key={index}>
             <TableCell>
-              <Box maxHeight="80px" display="flex" justifyContent="space-between" width="100%">
+              <Box maxHeight="80px" display="flex" alignItems="center" justifyContent="space-between" width="100%">
                 <Box flex="1" textAlign="left">
                   {output}
                 </Box>

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -451,7 +451,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                     Reduction start: {formatDateTime(reduction.reduction_start)}
                   </Typography>
                   <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
-                    Reduction end: {formatDateTime(reduction.reduction_start)}
+                    Reduction end: {formatDateTime(reduction.reduction_end)}
                   </Typography>
                   <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Good frames: {reduction.runs[0].good_frames.toLocaleString()}

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -128,6 +128,13 @@ const ReductionHistory: React.FC = () => {
     fetchReductions();
   };
 
+  const handleSort = (property: string): void => {
+    const isAsc = orderBy === property && orderDirection === 'asc';
+    setOrderDirection(isAsc ? 'desc' : 'asc');
+    setOrderBy(property);
+    setCurrentPage(0); // Reset to the first page
+  };
+
   const handleChangePage = (event: unknown, newPage: number): void => {
     setCurrentPage(newPage);
   };
@@ -191,11 +198,42 @@ const ReductionHistory: React.FC = () => {
                   <TableCell style={headerStyles} colSpan={2}>
                     {selectedInstrument}
                   </TableCell>
-                  <TableCell style={headerStyles}>Experiment number</TableCell>
-                  <TableCell style={headerStyles}>Filename</TableCell>
-                  <TableCell style={headerStyles}>Reduction start</TableCell>
-                  <TableCell style={headerStyles}>Reduction end</TableCell>
-                  <TableCell style={headerStyles}>Title</TableCell>
+                  <TableCell
+                    style={headerStyles}
+                    sortDirection={orderBy === 'experiment_number' ? orderDirection : false}
+                    onClick={() => handleSort('experiment_number')}
+                  >
+                    Experiment Number {orderBy === 'experiment_number' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
+                  </TableCell>
+                  <TableCell
+                    style={headerStyles}
+                    sortDirection={orderBy === 'filename' ? orderDirection : false}
+                    onClick={() => handleSort('filename')}
+                  >
+                    Filename {orderBy === 'filename' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
+                  </TableCell>
+                  <TableCell
+                    style={headerStyles}
+                    sortDirection={orderBy === 'reduction_start' ? orderDirection : false}
+                    onClick={() => handleSort('reduction_start')}
+                  >
+                    Reduction start {orderBy === 'reduction_start' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
+                  </TableCell>
+                  <TableCell
+                    style={headerStyles}
+                    sortDirection={orderBy === 'reduction_end' ? orderDirection : false}
+                    onClick={() => handleSort('reduction_end')}
+                  >
+                    Reduction end {orderBy === 'reduction_end' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
+                  </TableCell>
+                  {/* API currently doesn't allow for sorting by title so will crash the web app */}
+                  <TableCell
+                    style={headerStyles}
+                    sortDirection={orderBy === 'title' ? orderDirection : false}
+                    onClick={() => handleSort('title')}
+                  >
+                    Title {orderBy === 'title' ? (orderDirection === 'asc' ? '↑' : '↓') : ''}
+                  </TableCell>
                 </TableRow>
               </TableHead>
 
@@ -212,48 +250,48 @@ const ReductionHistory: React.FC = () => {
   );
 };
 
-const ReductionStatusIcon = ({ state }: { state: string }): JSX.Element => {
-  const getIconComponent = (): JSX.Element => {
-    switch (state) {
-      case 'ERROR':
-        return <ErrorOutlineIcon color="error" />;
-      case 'SUCCESSFUL':
-        return <CheckCircleOutlineIcon color="success" />;
-      case 'UNSUCCESSFUL':
-        return <WarningAmberIcon color="warning" />;
-      case 'NOT_STARTED':
-        return <HighlightOffIcon color="action" />;
-      default:
-        return <Icon>help_outline</Icon>;
-    }
-  };
-  return (
-    <Tooltip title={state}>
-      <span>{getIconComponent()}</span>
-    </Tooltip>
-  );
-};
-
-const formatDateTime = (dateTimeStr: string | null): string => {
-  if (dateTimeStr === null) {
-    return '';
-  }
-  return dateTimeStr.replace('T', '\n');
-};
-
-const extractFileName = (path: string): string => {
-  const fileNameWithExtension = path.split('/').pop();
-
-  if (typeof fileNameWithExtension === 'undefined') {
-    return '';
-  }
-  const fileName = fileNameWithExtension.split('.')[0];
-  return fileName;
-};
-
 function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX.Element {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
+
+  const ReductionStatusIcon = ({ state }: { state: string }): JSX.Element => {
+    const getIconComponent = (): JSX.Element => {
+      switch (state) {
+        case 'ERROR':
+          return <ErrorOutlineIcon color="error" />;
+        case 'SUCCESSFUL':
+          return <CheckCircleOutlineIcon color="success" />;
+        case 'UNSUCCESSFUL':
+          return <WarningAmberIcon color="warning" />;
+        case 'NOT_STARTED':
+          return <HighlightOffIcon color="action" />;
+        default:
+          return <Icon>help_outline</Icon>;
+      }
+    };
+    return (
+      <Tooltip title={state}>
+        <span>{getIconComponent()}</span>
+      </Tooltip>
+    );
+  };
+
+  const formatDateTime = (dateTimeStr: string | null): string => {
+    if (dateTimeStr === null) {
+      return '';
+    }
+    return dateTimeStr.replace('T', '\n');
+  };
+
+  const extractFileName = (path: string): string => {
+    const fileNameWithExtension = path.split('/').pop();
+
+    if (typeof fileNameWithExtension === 'undefined') {
+      return '';
+    }
+    const fileName = fileNameWithExtension.split('.')[0];
+    return fileName;
+  };
 
   const parseReductionOutputs = (): JSX.Element | JSX.Element[] | undefined => {
     try {
@@ -298,7 +336,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
     }
   };
 
-  const reductionStatusDisplay = (): JSX.Element => {
+  const renderReductionStatus = (): JSX.Element => {
     if (reduction.reduction_state === 'ERROR') {
       return (
         <Typography variant="subtitle1" style={{ color: 'red', fontWeight: 'bold' }}>
@@ -376,7 +414,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Box margin={2}>
               <Typography variant="h6" gutterBottom component="div">
-                {reductionStatusDisplay()}
+                {renderReductionStatus()}
               </Typography>
               <Grid container spacing={3}>
                 <Grid item xs={4}>

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -420,13 +420,21 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
               </Typography>
               <Grid container spacing={3}>
                 <Grid item xs={4}>
-                    Reduction ouputs
                   <Typography variant="h6" gutterBottom component="div" sx={{ fontWeight: 'bold' }}>
+                    {reduction.reduction_state === 'UNSUCCESSFUL' || reduction.reduction_state === 'ERROR'
+                      ? 'Stacktrace output'
+                      : 'Reduction outputs'}
                   </Typography>
                   <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
-                    <Table size="small" aria-label="details">
-                      <TableBody>{parseReductionOutputs()}</TableBody>
-                    </Table>
+                    {reduction.reduction_state === 'NOT_STARTED' ? (
+                      <Typography variant="body2" style={{ margin: 2 }}>
+                        No output files to show
+                      </Typography>
+                    ) : (
+                      <Table size="small" aria-label="details">
+                        <TableBody>{parseReductionOutputs()}</TableBody>
+                      </Table>
+                    )}
                   </Box>
                 </Grid>
                 <Grid item xs={3}>

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -302,7 +302,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                 <Box>
                   <Tooltip title="Will be added in the future">
                     <span>
-                      {/* Span is necessary because Tooltip doesn't work directly on disabled elements */}
+                      {/* Span is necessary because tooltip doesn't work directly on disabled elements */}
                       <Button variant="contained" style={{ marginLeft: '10px' }} disabled>
                         View
                       </Button>
@@ -310,7 +310,7 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                   </Tooltip>
                   <Tooltip title="Will be added in the future">
                     <span>
-                      {/* Span is necessary because Tooltip doesn't work directly on disabled elements */}
+                      {/* Span is necessary because tooltip doesn't work directly on disabled elements */}
                       <Button variant="contained" style={{ marginLeft: '10px' }} disabled>
                         Download
                       </Button>
@@ -468,7 +468,25 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                   <Typography variant="h6" gutterBottom component="div" sx={{ fontWeight: 'bold' }}>
                     Reduction inputs
                   </Typography>
-                  <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>{renderReductionInputs()}</Box>
+                  <Box sx={{ maxHeight: 140, overflowY: 'auto', marginBottom: 2 }}>{renderReductionInputs()}</Box>
+                  <Box>
+                    <Tooltip title="Will be added in the future">
+                      <span>
+                        {/* Span is necessary because tooltip doesn't work directly on disabled elements */}
+                        <Button variant="contained" sx={{ marginRight: 1 }} disabled>
+                          Value editor
+                        </Button>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="Will be added in the future">
+                      <span>
+                        {/* Span is necessary because tooltip doesn't work directly on disabled elements */}
+                        <Button variant="contained" color="primary" disabled>
+                          Rerun
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  </Box>
                 </Grid>
               </Grid>
             </Box>

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -1,62 +1,86 @@
+// React components
 import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { useTheme } from '@mui/material/styles';
+
+// Material UI components
 import {
-  Typography,
+  Box,
+  Button,
+  Collapse,
+  FormControl,
+  Grid,
+  Icon,
+  IconButton,
+  InputLabel,
+  Paper,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
+  TablePagination,
   TableRow,
-  Paper,
-  Pagination,
-  TableSortLabel,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
-  SelectChangeEvent,
-  Box,
   Tooltip,
-  styled,
+  Typography,
 } from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+
+// Local data
 import { instruments } from './InstrumentData';
 
+// Represents a single run with metadata and frame statistics
 interface Run {
   experiment_number: number;
   filename: string;
   run_start: string;
   run_end: string;
   title: string;
+  users: string;
+  good_frames: number;
+  raw_frames: number;
+  instrument_name: string;
 }
+
+// Describes the details of a reduction for one or more runs
 interface Reduction {
   id: number;
   reduction_start: string;
   reduction_end: string;
   reduction_state: string;
   reduction_status_message: string;
-  reduction_inputs: Record<string, string>;
+  reduction_inputs: {
+    [key: string]: string | number | boolean | null;
+  };
   reduction_outputs: string;
+  script: {
+    value: string;
+  };
   runs: Run[];
 }
 
 const ReductionHistory: React.FC = () => {
   const fiaApiUrl = process.env.REACT_APP_FIA_REST_API_URL;
-  const theme = useTheme();
   const history = useHistory();
+  const theme = useTheme();
   const { instrumentName } = useParams<{ instrumentName: string }>();
   const [reductions, setReductions] = useState<Reduction[]>([]);
   const [selectedInstrument, setSelectedInstrument] = useState<string>(instrumentName || instruments[0].name);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0); // Page index starts at 0 for TablePagination
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [totalRows, setTotalRows] = useState(0);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [orderBy, setOrderBy] = useState<string>('run_start');
-  const limit = 20;
 
   useEffect(() => {
     if (instrumentName && instruments.some((i) => i.name === instrumentName)) {
@@ -72,7 +96,7 @@ const ReductionHistory: React.FC = () => {
     try {
       const response = await fetch(`${fiaApiUrl}/instrument/${selectedInstrument}/reductions/count`);
       const data = await response.json();
-      setTotalPages(Math.ceil(data.count / limit));
+      setTotalRows(data.count);
     } catch (error) {
       console.error('Error fetching run count:', error);
     }
@@ -80,115 +104,55 @@ const ReductionHistory: React.FC = () => {
 
   const fetchReductions = useCallback(async (): Promise<void> => {
     try {
-      const offset = (currentPage - 1) * limit;
-      const query = `limit=${limit}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_runs=true`;
+      const offset = currentPage * rowsPerPage;
+      const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_runs=true`;
       const response = await fetch(`${fiaApiUrl}/instrument/${selectedInstrument}/reductions?${query}`);
       const data = await response.json();
       setReductions(data);
     } catch (error) {
-      console.error('Error fetching runs:', error);
+      console.error('Error fetching reductions:', error);
     }
-  }, [selectedInstrument, currentPage, orderBy, orderDirection, fiaApiUrl]);
+  }, [selectedInstrument, currentPage, rowsPerPage, orderBy, orderDirection, fiaApiUrl]);
 
   useEffect(() => {
     fetchTotalCount();
     fetchReductions();
-  }, [fetchTotalCount, fetchReductions]);
+  }, [fetchTotalCount, fetchReductions, currentPage, rowsPerPage]);
 
-  const handleSort = (property: string): void => {
-    const isAsc = orderBy === property && orderDirection === 'asc';
-    setOrderDirection(isAsc ? 'desc' : 'asc');
-    setOrderBy(property);
-  };
-
-  const handlePageChange = (event: React.ChangeEvent<unknown>, page: number): void => {
-    setCurrentPage(page);
-  };
-
-  const handleInstrumentChange = (event: SelectChangeEvent): void => {
-    const newInstrument = event.target.value as string;
+  const handleInstrumentChange = (event: SelectChangeEvent<string>): void => {
+    const newInstrument = event.target.value;
     setSelectedInstrument(newInstrument);
-    setCurrentPage(1); // Reset to page 1 when the instrument changes
+    setCurrentPage(0);
     history.push(`/reduction-history/${newInstrument}`);
     fetchTotalCount();
     fetchReductions();
   };
 
-  const StyledTableRow = styled(TableRow)(({ theme }) => ({
-    '&:nth-of-type(odd)': {
-      backgroundColor: theme.palette.action.hover,
+  const handleChangePage = (event: unknown, newPage: number): void => {
+    setCurrentPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setCurrentPage(0);
+  };
+
+  const headerStyles = {
+    color: 'white',
+    backgroundColor: '#003088',
+    fontWeight: 'bold',
+    borderRight: `1px solid #1f4996`,
+    '&:last-child': {
+      borderRight: 'none',
     },
-    '&:nth-of-type(even)': {
-      backgroundColor: theme.palette.mode === 'dark' ? theme.palette.background.default : 'white',
-    },
-  }));
-
-  const formatDateTime = (dateTimeStr: string | null): string => {
-    if (dateTimeStr === null) {
-      return '';
-    }
-    return dateTimeStr.replace('T', '\n');
   };
-
-  const extractFileName = (path: string): string => {
-    const fileNameWithExtension = path.split('/').pop();
-
-    if (typeof fileNameWithExtension === 'undefined') {
-      return '';
-    }
-    const fileName = fileNameWithExtension.split('.')[0];
-    return fileName;
-  };
-
-  const ReductionStatusIcon = ({ state, statusMessage }: { state: string; statusMessage: string }): JSX.Element => {
-    let IconComponent;
-    let color;
-
-    switch (state) {
-      case 'ERROR':
-        IconComponent = ErrorOutlineIcon;
-        color = 'red';
-        break;
-      case 'SUCCESSFUL':
-        IconComponent = CheckCircleOutlineIcon;
-        color = 'green';
-        break;
-      case 'UNSUCCESSFUL':
-        IconComponent = WarningAmberIcon;
-        color = 'orange';
-        break;
-      case 'NOT_STARTED':
-        IconComponent = HighlightOffIcon;
-        color = 'grey';
-        break;
-      default:
-        IconComponent = ErrorOutlineIcon;
-        color = 'disabled';
-        statusMessage = 'Unknown status';
-    }
-    return (
-      <Tooltip title={statusMessage}>
-        <div>
-          <IconComponent style={{ color }} />
-        </div>
-      </Tooltip>
-    );
-  };
-
-  const StyledTableCell = styled(TableCell)(({ theme }) => ({
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    minWidth: 160,
-  }));
 
   return (
     <div style={{ padding: '20px' }}>
       <Box display="flex" alignItems="center" justifyContent="space-between" marginBottom="20px">
         <Typography variant="h3" component="h1" style={{ color: theme.palette.text.primary }}>
-          {`${selectedInstrument.toUpperCase()} Reduction History`}
+          {selectedInstrument.toUpperCase()} reduction history
         </Typography>
-
         <FormControl style={{ width: '200px', marginLeft: '20px' }}>
           <InputLabel id="instrument-select-label">Instrument</InputLabel>
           <Select
@@ -198,7 +162,7 @@ const ReductionHistory: React.FC = () => {
             onChange={handleInstrumentChange}
           >
             {instruments.map((instrument) => (
-              <MenuItem key={instrument.id} value={instrument.name}>
+              <MenuItem key={instrument.name} value={instrument.name}>
                 {instrument.name}
               </MenuItem>
             ))}
@@ -206,112 +170,264 @@ const ReductionHistory: React.FC = () => {
         </FormControl>
       </Box>
 
-      <TableContainer component={Paper}>
-        <Table sx={{ minWidth: 650 }} aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'experiment_number'}
-                  direction={orderBy === 'experiment_number' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('experiment_number')}
-                >
-                  Experiment Number
-                </TableSortLabel>
-              </StyledTableCell>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'filename'}
-                  direction={orderBy === 'filename' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('filename')}
-                >
-                  Reduction Input
-                </TableSortLabel>
-              </StyledTableCell>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'run_start'}
-                  direction={orderBy === 'run_start' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('run_start')}
-                >
-                  Run Start
-                </TableSortLabel>
-              </StyledTableCell>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'run_end'}
-                  direction={orderBy === 'run_end' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('run_end')}
-                >
-                  Run End
-                </TableSortLabel>
-              </StyledTableCell>
-              <StyledTableCell>Title</StyledTableCell>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'reduction_start'}
-                  direction={orderBy === 'reduction_start' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('reduction_start')}
-                >
-                  Reduction Start
-                </TableSortLabel>
-              </StyledTableCell>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'reduction_end'}
-                  direction={orderBy === 'reduction_end' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('reduction_end')}
-                >
-                  Reduction End
-                </TableSortLabel>
-              </StyledTableCell>
-              <StyledTableCell>
-                <TableSortLabel
-                  active={orderBy === 'reduction_outputs'}
-                  direction={orderBy === 'reduction_outputs' ? orderDirection : 'asc'}
-                  onClick={() => handleSort('reduction_outputs')}
-                >
-                  Reduction Outputs
-                </TableSortLabel>
-              </StyledTableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {reductions.map((reduction, index) => (
-              <StyledTableRow key={index}>
-                <TableCell>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <ReductionStatusIcon
-                      state={reduction.reduction_state}
-                      statusMessage={reduction.reduction_status_message}
-                    />
-                    <span style={{ marginLeft: '40px' }}>{reduction.runs[0].experiment_number}</span>
-                  </div>
-                </TableCell>
-                <TableCell>{extractFileName(reduction.runs[0].filename)}</TableCell>
-                <TableCell>{formatDateTime(reduction.runs[0].run_start)}</TableCell>
-                <TableCell>{formatDateTime(reduction.runs[0].run_end)}</TableCell>
-                <TableCell>{reduction.runs[0].title}</TableCell>
-                <TableCell>{formatDateTime(reduction.reduction_start)}</TableCell>
-                <TableCell>{formatDateTime(reduction.reduction_end)}</TableCell>
-                <TableCell>{reduction.reduction_outputs}</TableCell>
-              </StyledTableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      {reductions.length === 0 ? (
+        <Typography variant="h6" style={{ textAlign: 'center', marginTop: '20px', color: theme.palette.text.primary }}>
+          No reductions to show for this instrument
+        </Typography>
+      ) : (
+        <>
+          <TablePagination
+            component="div"
+            count={totalRows}
+            page={currentPage}
+            onPageChange={handleChangePage}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
+          <TableContainer component={Paper} style={{ maxHeight: '740px', overflowY: 'scroll' }}>
+            <Table aria-label="collapsible table" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell style={headerStyles} colSpan={2}>
+                    {selectedInstrument}
+                  </TableCell>
+                  <TableCell style={headerStyles}>Experiment number</TableCell>
+                  <TableCell style={headerStyles}>Filename</TableCell>
+                  <TableCell style={headerStyles}>Reduction start</TableCell>
+                  <TableCell style={headerStyles}>Reduction end</TableCell>
+                  <TableCell style={headerStyles}>Title</TableCell>
+                </TableRow>
+              </TableHead>
 
-      {totalPages > 1 && (
-        <Pagination
-          count={totalPages}
-          page={currentPage}
-          onChange={handlePageChange}
-          color="primary"
-          sx={{ marginTop: 2, marginBottom: 2 }}
-        />
+              <TableBody>
+                {reductions.map((reduction, index) => (
+                  <Row key={reduction.id} reduction={reduction} index={index} />
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
       )}
     </div>
   );
 };
+
+const ReductionStatusIcon = ({ state }: { state: string }): JSX.Element => {
+  const getIconComponent = (): JSX.Element => {
+    switch (state) {
+      case 'ERROR':
+        return <ErrorOutlineIcon color="error" />;
+      case 'SUCCESSFUL':
+        return <CheckCircleOutlineIcon color="success" />;
+      case 'UNSUCCESSFUL':
+        return <WarningAmberIcon color="warning" />;
+      case 'NOT_STARTED':
+        return <HighlightOffIcon color="action" />;
+      default:
+        return <Icon>help_outline</Icon>;
+    }
+  };
+  return (
+    <Tooltip title={state}>
+      <span>{getIconComponent()}</span>
+    </Tooltip>
+  );
+};
+
+const formatDateTime = (dateTimeStr: string | null): string => {
+  if (dateTimeStr === null) {
+    return '';
+  }
+  return dateTimeStr.replace('T', '\n');
+};
+
+const extractFileName = (path: string): string => {
+  const fileNameWithExtension = path.split('/').pop();
+
+  if (typeof fileNameWithExtension === 'undefined') {
+    return '';
+  }
+  const fileName = fileNameWithExtension.split('.')[0];
+  return fileName;
+};
+
+function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const theme = useTheme();
+
+  const parseReductionOutputs = (): JSX.Element | JSX.Element[] | undefined => {
+    try {
+      // Replace single quotes with double quotes to form a valid JSON string
+      const preProcessed = reduction.reduction_outputs.replace(/'/g, '"');
+      const parsed = JSON.parse(preProcessed);
+
+      if (Array.isArray(parsed)) {
+        return parsed.map((output, index: number) => (
+          <TableRow key={index}>
+            <TableCell>
+              <Box maxHeight="80px" display="flex" justifyContent="space-between" width="100%">
+                <Box flex="1" textAlign="left">
+                  {output}
+                </Box>
+                <Box>
+                  <Button variant="contained" style={{ marginLeft: '10px' }}>
+                    View
+                  </Button>
+                  <Tooltip title="Will be added in the future">
+                    <span>
+                      {/* Span is necessary because Tooltip doesn't work directly on disabled elements */}
+                      <Button variant="contained" style={{ marginLeft: '10px' }} disabled>
+                        Download
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </Box>
+              </Box>
+            </TableCell>
+          </TableRow>
+        ));
+      }
+    } catch (error) {
+      console.error('Failed to parse reduction_outputs as JSON:', reduction.reduction_outputs);
+      console.error('Error:', error);
+      return (
+        <TableRow>
+          <TableCell>{reduction.reduction_outputs}</TableCell>
+        </TableRow>
+      );
+    }
+  };
+
+  const reductionStatusDisplay = (): JSX.Element => {
+    if (reduction.reduction_state === 'ERROR') {
+      return (
+        <Typography variant="subtitle1" style={{ color: 'red', fontWeight: 'bold' }}>
+          [ERROR] {reduction.reduction_status_message}: src\ReductionHistory.tsx Line 206:25: Missing return type on
+          function @typescript-eslint/explicit-function-return-type
+        </Typography>
+      );
+    } else if (reduction.reduction_state === 'SUCCESSFUL') {
+      return (
+        <Typography variant="subtitle1" style={{ color: '#2e7d32', fontWeight: 'bold' }}>
+          [SUCCESS] Reduction performed successfully
+        </Typography>
+      );
+    } else if (reduction.reduction_state === 'NOT_STARTED') {
+      return (
+        <Typography variant="subtitle1" style={{ color: 'gray', fontWeight: 'bold' }}>
+          [NOT STARTED] This reduction has not been started yet
+        </Typography>
+      );
+    } else {
+      return <></>;
+    }
+  };
+
+  const renderReductionInputs = (): JSX.Element | JSX.Element[] => {
+    const entries = Object.entries(reduction.reduction_inputs);
+    if (entries.length === 0) {
+      return <Typography>No input data available.</Typography>;
+    }
+
+    return entries.map(([key, value], index) => (
+      <Typography key={index} variant="body2">
+        {`${key}: ${value}`}
+      </Typography>
+    ));
+  };
+
+  const rowStyles = {
+    backgroundColor:
+      index % 2 === 0
+        ? theme.palette.mode === 'light'
+          ? '#ececec'
+          : '#2d2d2d' // Conditionally set for even rows based on theme mode
+        : theme.palette.background.default, // Default for odd rows
+  };
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          '& > *': { borderBottom: 'unset' },
+          ...rowStyles,
+          '&:hover': { backgroundColor: theme.palette.action.hover },
+        }}
+        onClick={() => setOpen(!open)}
+      >
+        <TableCell>
+          <IconButton aria-label="expand row" size="small">
+            {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell>
+          <ReductionStatusIcon state={reduction.reduction_state} />
+        </TableCell>
+        <TableCell component="th" scope="row">
+          {reduction.runs[0].experiment_number}
+        </TableCell>
+        <TableCell>{extractFileName(reduction.runs[0].filename)}</TableCell>
+        <TableCell>{formatDateTime(reduction.reduction_start)}</TableCell>
+        <TableCell>{formatDateTime(reduction.reduction_end)}</TableCell>
+        <TableCell>{reduction.runs[0].title}</TableCell>
+      </TableRow>
+      <TableRow sx={rowStyles}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={7}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box margin={2}>
+              <Typography variant="h6" gutterBottom component="div">
+                {reductionStatusDisplay()}
+              </Typography>
+              <Grid container spacing={3}>
+                <Grid item xs={4}>
+                  <Typography variant="h6" gutterBottom component="div">
+                    Reduction ouputs
+                  </Typography>
+                  <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
+                    <Table size="small" aria-label="details">
+                      <TableBody>{parseReductionOutputs()}</TableBody>
+                    </Table>
+                  </Box>
+                </Grid>
+                <Grid item xs={3}>
+                  <Typography variant="h6" gutterBottom component="div">
+                    Run details
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    Reduction ID: {reduction.id}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    Instrument: {reduction.runs[0].instrument_name}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    Start: {formatDateTime(reduction.runs[0].run_start)}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    End: {formatDateTime(reduction.runs[0].run_end)}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    Good frames: {reduction.runs[0].good_frames.toLocaleString()}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    Raw frames: {reduction.runs[0].raw_frames.toLocaleString()}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    Users: {reduction.runs[0].users}
+                  </Typography>
+                </Grid>
+                <Grid item xs={5}>
+                  <Typography variant="h6" gutterBottom component="div">
+                    Reduction inputs
+                  </Typography>
+                  <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>{renderReductionInputs()}</Box>
+                </Grid>
+              </Grid>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+}
 
 export default ReductionHistory;

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -361,11 +361,11 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
   const renderReductionInputs = (): JSX.Element | JSX.Element[] => {
     const entries = Object.entries(reduction.reduction_inputs);
     if (entries.length === 0) {
-      return <Typography>No input data available.</Typography>;
+      return <Typography sx={{ fontWeight: 'bold' }}>No input data available</Typography>;
     }
 
     return entries.map(([key, value], index) => (
-      <Typography key={index} variant="body2">
+      <Typography key={index} variant="body2" sx={{ fontWeight: 'bold' }}>
         {`${key}: ${value}`}
       </Typography>
     ));
@@ -415,8 +415,8 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
               </Typography>
               <Grid container spacing={3}>
                 <Grid item xs={4}>
-                  <Typography variant="h6" gutterBottom component="div">
                     Reduction ouputs
+                  <Typography variant="h6" gutterBottom component="div" sx={{ fontWeight: 'bold' }}>
                   </Typography>
                   <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
                     <Table size="small" aria-label="details">
@@ -425,33 +425,34 @@ function Row({ reduction, index }: { reduction: Reduction; index: number }): JSX
                   </Box>
                 </Grid>
                 <Grid item xs={3}>
-                  <Typography variant="h6" gutterBottom component="div">
+                  <Typography variant="h6" gutterBottom component="div" sx={{ fontWeight: 'bold' }}>
                     Run details
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Reduction ID: {reduction.id}
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Instrument: {reduction.runs[0].instrument_name}
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Reduction start: {formatDateTime(reduction.reduction_start)}
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Reduction end: {formatDateTime(reduction.reduction_start)}
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Good frames: {reduction.runs[0].good_frames.toLocaleString()}
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Raw frames: {reduction.runs[0].raw_frames.toLocaleString()}
                   </Typography>
-                  <Typography variant="body2" gutterBottom>
+                  <Typography variant="body2" gutterBottom sx={{ fontWeight: 'bold' }}>
                     Users: {reduction.runs[0].users}
                   </Typography>
                 </Grid>
+
                 <Grid item xs={5}>
-                  <Typography variant="h6" gutterBottom component="div">
+                  <Typography variant="h6" gutterBottom component="div" sx={{ fontWeight: 'bold' }}>
                     Reduction inputs
                   </Typography>
                   <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>{renderReductionInputs()}</Box>

--- a/src/ReductionHistory.tsx
+++ b/src/ReductionHistory.tsx
@@ -80,6 +80,8 @@ const ReductionHistory: React.FC = () => {
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
   const [orderBy, setOrderBy] = useState<string>('run_start');
 
+  console.log('xDDDDDD', theme.palette.mode);
+
   useEffect(() => {
     if (instrumentName && instruments.some((i) => i.name === instrumentName)) {
       setSelectedInstrument(instrumentName);
@@ -144,7 +146,7 @@ const ReductionHistory: React.FC = () => {
 
   const headerStyles = {
     color: 'white',
-    backgroundColor: '#003088',
+    backgroundColor: theme.palette.primary.main,
     fontWeight: 'bold',
     borderRight: `1px solid #1f4996`,
     '&:last-child': {


### PR DESCRIPTION
Closes #106, closes #105, closes #104, closes #73.

## Description

Updates the reduction history page to be more fluid by using a collapsible table.

## How to test

Set the fronted end to use the live API and then run through SciGateway. Navigate to the reduction history page and then browse runs for the MARI instrument.