### PR TITLE
Re-implement config page into a sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 // React components
 import React, { FC } from 'react';
-import { BrowserRouter as Router, Route, Switch, useParams } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import ReactGA from 'react-ga4';
 
 // Local data
@@ -9,8 +9,6 @@ import JobsAll from './Jobs/JobsAll';
 import JobsGeneral from './Jobs/JobsGeneral';
 import HomePage from './HomePage';
 import ValueEditor from './ValueEditor';
-import ConfigSettingsGeneral from './ConfigSettings/ConfigSettingsGeneral';
-import ConfigSettingsLOQ from './ConfigSettings/ConfigSettingsLOQ';
 import GlobalStyles from './GlobalStyles';
 
 // Initialize Google Analytics
@@ -39,18 +37,6 @@ const App: FC = () => {
     };
   }, []);
 
-  // Conditionally render the appropriate ConfigSettings page
-  const ConfigSettingsPage: FC = () => {
-    const { instrumentName } = useParams<{ instrumentName: string }>();
-
-    switch (instrumentName) {
-      case 'LOQ':
-        return <ConfigSettingsLOQ />;
-      default:
-        return <ConfigSettingsGeneral />;
-    }
-  };
-
   return (
     <GlobalStyles>
       <Router basename="/fia">
@@ -69,9 +55,6 @@ const App: FC = () => {
           </Route>
           <Route path="/value-editor/:jobId">
             <ValueEditor />
-          </Route>
-          <Route path="/:instrumentName/config-settings">
-            <ConfigSettingsPage />
           </Route>
         </Switch>
       </Router>

--- a/src/ConfigSettings/ConfigSettingsGeneral.tsx
+++ b/src/ConfigSettings/ConfigSettingsGeneral.tsx
@@ -274,6 +274,10 @@ const ConfigSettingsGeneral: React.FC<ConfigSettingsGeneralProps> = ({ children 
             value={jsonContent}
             theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'vs-light'}
             onChange={handleEditorChange}
+            options={{
+              wordWrap: 'on',
+              minimap: { enabled: false },
+            }}
           />
         </Box>
       </TabPanel>

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -618,9 +618,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
           },
         }}
       >
-        <Box>
-          {renderConfigSettings()}
-        </Box>
+        <Box>{renderConfigSettings()}</Box>
       </Drawer>
 
       {jobs.length === 0 ? (

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -172,7 +172,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   const baseColumnCount = 7; // Number of base columns defined in the TableHead
   const customColumnCount = customHeaders ? 1 : 0;
   const totalColumnCount = baseColumnCount + customColumnCount;
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   useEffect(() => {
     fetchTotalCount();
@@ -206,11 +206,11 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   };
 
   const openConfigSettings = (): void => {
-    setIsDrawerOpen(true);
+    setDrawerOpen(true);
   };
 
   const closeConfigSettings = (): void => {
-    setIsDrawerOpen(false);
+    setDrawerOpen(false);
   };
 
   const renderConfigSettings = (): JSX.Element => {
@@ -608,7 +608,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
 
       <Drawer
         anchor="right"
-        open={isDrawerOpen}
+        open={drawerOpen}
         onClose={closeConfigSettings}
         sx={{
           '& .MuiDrawer-paper': {

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
   Collapse,
+  Drawer,
   FormControl,
   IconButton,
   InputLabel,
@@ -47,6 +48,8 @@ import { CSSObject } from '@mui/system';
 
 // Local data
 import { instruments } from '../InstrumentData';
+import ConfigSettingsGeneral from '../ConfigSettings/ConfigSettingsGeneral';
+import ConfigSettingsLOQ from '../ConfigSettings/ConfigSettingsLOQ';
 
 export const headerStyles = (theme: Theme): CSSObject => ({
   color: theme.palette.primary.contrastText,
@@ -169,6 +172,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   const baseColumnCount = 7; // Number of base columns defined in the TableHead
   const customColumnCount = customHeaders ? 1 : 0;
   const totalColumnCount = baseColumnCount + customColumnCount;
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   useEffect(() => {
     fetchTotalCount();
@@ -202,9 +206,20 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   };
 
   const openConfigSettings = (): void => {
-    const url = `/fia/${selectedInstrument}/config-settings`;
-    const features = 'width=1028,height=900,resizable=no';
-    window.open(url, 'ConfigSettingsWindow', features);
+    setIsDrawerOpen(true);
+  };
+
+  const closeConfigSettings = (): void => {
+    setIsDrawerOpen(false);
+  };
+
+  const renderConfigSettings = (): JSX.Element => {
+    switch (selectedInstrument) {
+      case 'LOQ':
+        return <ConfigSettingsLOQ />;
+      default:
+        return <ConfigSettingsGeneral />;
+    }
   };
 
   const Row: React.FC<{ job: Job; index: number }> = ({ job, index }) => {
@@ -590,6 +605,23 @@ const JobsBase: React.FC<JobsBaseProps> = ({
 
       {/* Render children passed from parent */}
       {children}
+
+      <Drawer
+        anchor="right"
+        open={isDrawerOpen}
+        onClose={closeConfigSettings}
+        sx={{
+          '& .MuiDrawer-paper': {
+            width: '600px',
+            padding: '16px',
+            backgroundColor: theme.palette.background.default,
+          },
+        }}
+      >
+        <Box>
+          {renderConfigSettings()}
+        </Box>
+      </Drawer>
 
       {jobs.length === 0 ? (
         <Typography variant="h6" style={{ textAlign: 'center', marginTop: '20px', color: theme.palette.text.primary }}>

--- a/src/Jobs/JobsGeneral.tsx
+++ b/src/Jobs/JobsGeneral.tsx
@@ -53,7 +53,7 @@ const JobsGeneral: React.FC = () => {
       orderDirection={orderDirection}
       fetchJobs={fetchJobs}
       fetchTotalCount={fetchTotalCount}
-      showConfigButton={selectedInstrument === 'LOQ'}
+      showConfigButton={selectedInstrument === 'LOQ' || selectedInstrument === 'MARI'}
     >
       <Typography
         variant="body1"


### PR DESCRIPTION
Closes #346.

## Description

Pressing the "Config" button on the reduction history page should now open a sidebar instead of a minimized window.