### PR TITLE
Limit link width

### DIFF
--- a/src/Jobs/JobsGeneral.tsx
+++ b/src/Jobs/JobsGeneral.tsx
@@ -66,6 +66,7 @@ const JobsGeneral: React.FC = () => {
           alignItems: 'center',
           textDecoration: 'none',
           marginTop: '10px',
+          width: 'fit-content',
           '&:hover': {
             textDecoration: 'underline',
           },


### PR DESCRIPTION
Closes #369.

## Description

Limits the bounding element for the link used for navigating from a specific instrument history page to the all history page to.