### PR TITLE
Enable rerun button

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
-# This needs to include the http:// or https:// part of the URL
-
 REACT_APP_FIA_REST_API_URL=https://dev.reduce.isis.cclrc.ac.uk/api
 REACT_APP_FIA_DATA_VIEWER_URL=https://dev.reduce.isis.cclrc.ac.uk/data-viewer
 REACT_APP_PLUGIN_URL=http://localhost:5001
 REACT_APP_DEV_MODE=false
+REACT_APP_GITHUB_TOKEN=<YOUR TOKEN>

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -587,7 +587,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                       </Button>
                       <Button
                         variant="contained"
-                        sx={{ marginLeft: 1, width: 40 }}
+                        sx={{ marginLeft: 1, width: 60 }}
                         disabled={loading}
                         onClick={handleRerun}
                       >

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -297,7 +297,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                   <Box>
                     <Button
                       variant="contained"
-                      style={{ marginLeft: '10px' }}
+                      sx={{ marginLeft: 1 }}
                       onClick={() =>
                         openDataViewer(
                           job.id,
@@ -311,7 +311,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                     </Button>
                     <Tooltip title="Will be added in the future">
                       <span>
-                        <Button variant="contained" style={{ marginLeft: '10px' }} disabled>
+                        <Button variant="contained" sx={{ marginLeft: 1 }} disabled>
                           Download
                         </Button>
                       </span>
@@ -545,16 +545,12 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                     </Typography>
                     <Box sx={{ maxHeight: 160, overflowY: 'auto', marginBottom: 2 }}>{renderJobInputs()}</Box>
                     <Box display="flex" justifyContent="right">
-                      <Button variant="contained" sx={{ marginRight: 1 }} onClick={() => openValueEditor(job.id)}>
+                      <Button variant="contained" onClick={() => openValueEditor(job.id)}>
                         Value editor
                       </Button>
-                      <Tooltip title="Will be added in the future">
-                        <span>
-                          <Button variant="contained" color="primary" disabled>
-                            Rerun
-                          </Button>
-                        </span>
-                      </Tooltip>
+                      <Button variant="contained" sx={{ marginLeft: 1 }}>
+                        Rerun
+                      </Button>
                     </Box>
                   </Grid>
                 </Grid>

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -585,7 +585,12 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                       <Button variant="contained" onClick={() => openValueEditor(job.id)}>
                         Value editor
                       </Button>
-                      <Button variant="contained" sx={{ marginLeft: 1 }} disabled={loading} onClick={handleRerun}>
+                      <Button
+                        variant="contained"
+                        sx={{ marginLeft: 1, width: 40 }}
+                        disabled={loading}
+                        onClick={handleRerun}
+                      >
                         {loading ? <CircularProgress size={24} color="inherit" /> : 'Rerun'}
                       </Button>
                     </Box>

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -407,9 +407,6 @@ const JobsBase: React.FC<JobsBaseProps> = ({
         if (!response.ok) {
           throw new Error(`Failed to rerun job: ${response.statusText}`);
         }
-
-        const result = await response.json();
-        console.log('Rerun successful:', result);
       } catch (error) {
         console.error('Error rerunning job:', error);
       } finally {

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -629,7 +629,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                       </Button>
                       <Button
                         variant="contained"
-                        sx={{ marginLeft: 2, width: 60 }}
+                        sx={{ marginLeft: 2, width: 60, height: 38 }}
                         disabled={loading}
                         onClick={handleRerun}
                       >

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -478,7 +478,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              border: '2px solid',
+              border: '1px solid',
               borderRadius: '8px',
               fontWeight: 'bold',
             }}

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -29,20 +29,20 @@ import {
   useTheme,
 } from '@mui/material';
 import {
+  CheckCircleOutline,
+  ErrorOutline,
+  ImageAspectRatio,
+  HighlightOff,
   KeyboardArrowDown,
   KeyboardArrowUp,
-  ErrorOutline,
-  CheckCircleOutline,
-  HighlightOff,
-  WarningAmber,
-  WorkOutline,
   People,
   Schedule,
-  VpnKey,
-  StackedBarChart,
   Schema,
   Settings,
-  ImageAspectRatio,
+  StackedBarChart,
+  VpnKey,
+  WarningAmber,
+  WorkOutline,
 } from '@mui/icons-material';
 import Grid from '@mui/material/Grid2';
 import { CSSObject } from '@mui/system';

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -178,6 +178,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const rerunSuccessful = useRef<boolean | null>(null);
+  const rerunJobId = useRef<number | null>(null);
 
   useEffect(() => {
     fetchTotalCount();
@@ -389,7 +390,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
 
     const handleRerun = async (): Promise<void> => {
       setLoading(true);
-
+      rerunJobId.current = job.id;
       try {
         const isDev = process.env.REACT_APP_DEV_MODE === 'true';
         const token = isDev ? null : localStorage.getItem('scigateway:token');
@@ -459,19 +460,34 @@ const JobsBase: React.FC<JobsBaseProps> = ({
       <>
         <Snackbar
           open={snackbarOpen}
-          autoHideDuration={4000}
-          onClose={() => {
-            setSnackbarOpen(false);
+          autoHideDuration={5000}
+          onClose={(event, reason) => {
+            if (reason !== 'clickaway') {
+              setSnackbarOpen(false);
+            }
           }}
+          disableWindowBlurListener={false}
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         >
-          {rerunSuccessful.current ? (
-            <Alert severity="success">Rerun started successfully for reduction {job.id}</Alert>
-          ) : (
-            <Alert severity="error">
-              Rerun could not be started for {job.id} — please try again later or contact staff
-            </Alert>
-          )}
+          <Alert
+            sx={{
+              padding: '10px 14px',
+              fontSize: '1rem',
+              width: '100%',
+              maxWidth: '600px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '2px solid',
+              borderRadius: '8px',
+              fontWeight: 'bold',
+            }}
+            severity={rerunSuccessful.current ? 'success' : 'error'}
+          >
+            {rerunSuccessful.current
+              ? `Rerun started successfully for reduction ${rerunJobId.current}`
+              : `Rerun could not be started for ${rerunJobId.current} — please try again later or contact staff`}
+          </Alert>
         </Snackbar>
 
         <TableRow sx={{ ...rowStyles, '&:hover': hoverStyles(theme, index) }} onClick={() => setOpen(!open)}>

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -6,6 +6,7 @@ import ReactGA from 'react-ga4';
 import {
   Box,
   Button,
+  CircularProgress,
   Collapse,
   Drawer,
   FormControl,
@@ -225,6 +226,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   const Row: React.FC<{ job: Job; index: number }> = ({ job, index }) => {
     const [open, setOpen] = useState(false);
     const theme = useTheme();
+    const [loading, setLoading] = useState(false);
     const fiaApiUrl = process.env.REACT_APP_FIA_REST_API_URL;
 
     const JobStatus = ({ state }: { state: string }): JSX.Element => {
@@ -382,11 +384,12 @@ const JobsBase: React.FC<JobsBaseProps> = ({
     };
 
     const handleRerun = async (): Promise<void> => {
+      setLoading(true);
+
       try {
         const isDev = process.env.REACT_APP_DEV_MODE === 'true';
         const token = isDev ? null : localStorage.getItem('scigateway:token');
         const headers: { [key: string]: string } = { 'Content-Type': 'application/json' };
-
         if (token) {
           headers['Authorization'] = `Bearer ${token}`;
         }
@@ -409,6 +412,8 @@ const JobsBase: React.FC<JobsBaseProps> = ({
         console.log('Rerun successful:', result);
       } catch (error) {
         console.error('Error rerunning job:', error);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -580,8 +585,8 @@ const JobsBase: React.FC<JobsBaseProps> = ({
                       <Button variant="contained" onClick={() => openValueEditor(job.id)}>
                         Value editor
                       </Button>
-                      <Button variant="contained" sx={{ marginLeft: 1 }} onClick={handleRerun}>
-                        Rerun
+                      <Button variant="contained" sx={{ marginLeft: 1 }} disabled={loading} onClick={handleRerun}>
+                        {loading ? <CircularProgress size={24} color="inherit" /> : 'Rerun'}
                       </Button>
                     </Box>
                   </Grid>

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -457,6 +457,23 @@ const JobsBase: React.FC<JobsBaseProps> = ({
 
     return (
       <>
+        <Snackbar
+          open={snackbarOpen.current}
+          autoHideDuration={4000}
+          onClose={() => {
+            snackbarOpen.current = false;
+          }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        >
+          {rerunSuccessful.current ? (
+            <Alert severity="success">Rerun started successfully for reduction {job.id}</Alert>
+          ) : (
+            <Alert severity="error">
+              Rerun could not be started for {job.id} — please try again later or contact staff
+            </Alert>
+          )}
+        </Snackbar>
+
         <TableRow sx={{ ...rowStyles, '&:hover': hoverStyles(theme, index) }} onClick={() => setOpen(!open)}>
           <TableCell sx={{ width: '4%' }}>
             <IconButton aria-label="expand row" size="small">
@@ -649,21 +666,6 @@ const JobsBase: React.FC<JobsBaseProps> = ({
           )}
         </Box>
       </Box>
-
-      <Snackbar
-        open={snackbarOpen.current}
-        autoHideDuration={4000}
-        onClose={() => {
-          snackbarOpen.current = false;
-        }}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
-        {rerunSuccessful.current ? (
-          <Alert severity="success">Rerun started successfully</Alert>
-        ) : (
-          <Alert severity="error">Rerun could not be started - please try again later or contact staff</Alert>
-        )}
-      </Snackbar>
 
       {/* Render children passed from parent */}
       {children}

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -176,7 +176,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   const customColumnCount = customHeaders ? 1 : 0;
   const totalColumnCount = baseColumnCount + customColumnCount;
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const snackbarOpen = useRef(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
   const rerunSuccessful = useRef<boolean | null>(null);
 
   useEffect(() => {
@@ -420,7 +420,7 @@ const JobsBase: React.FC<JobsBaseProps> = ({
       } finally {
         setTimeout(async () => {
           setLoading(false);
-          snackbarOpen.current = true;
+          setSnackbarOpen(true);
           await fetchJobs();
         }, 2000);
       }
@@ -458,10 +458,10 @@ const JobsBase: React.FC<JobsBaseProps> = ({
     return (
       <>
         <Snackbar
-          open={snackbarOpen.current}
+          open={snackbarOpen}
           autoHideDuration={4000}
           onClose={() => {
-            snackbarOpen.current = false;
+            setSnackbarOpen(false);
           }}
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         >

--- a/src/ValueEditor.tsx
+++ b/src/ValueEditor.tsx
@@ -35,7 +35,7 @@ const ValueEditor: React.FC = () => {
   const theme = useTheme();
   const [value, setValue] = useState<number>(0);
   const [runnerVersion, setRunnerVersion] = useState<string>('1');
-  const { reductionId } = useParams<{ reductionId: string }>();
+  const { jobId: jobId } = useParams<{ jobId: string }>();
   const [scriptValue, setScriptValue] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const fiaApiUrl = process.env.REACT_APP_FIA_REST_API_URL;
@@ -46,13 +46,15 @@ const ValueEditor: React.FC = () => {
       const isDev = process.env.REACT_APP_DEV_MODE === 'true';
       const token = isDev ? null : localStorage.getItem('scigateway:token');
       const headers: { [key: string]: string } = { 'Content-Type': 'application/json' };
+
       if (token) {
         headers['Authorization'] = `Bearer ${token}`;
       }
-      const response = await fetch(`${fiaApiUrl}/job/${reductionId}`, {
+      const response = await fetch(`${fiaApiUrl}/job/${jobId}`, {
         method: 'GET',
         headers,
       });
+
       const data = await response.json();
       if (data && data.script && data.script.value) {
         setScriptValue(data.script.value);
@@ -62,7 +64,7 @@ const ValueEditor: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [fiaApiUrl, reductionId]);
+  }, [fiaApiUrl, jobId]);
 
   useEffect(() => {
     fetchReduction();

--- a/src/ValueEditor.tsx
+++ b/src/ValueEditor.tsx
@@ -35,7 +35,7 @@ const ValueEditor: React.FC = () => {
   const theme = useTheme();
   const [value, setValue] = useState<number>(0);
   const [runnerVersion, setRunnerVersion] = useState<string>('1');
-  const { jobId: jobId } = useParams<{ jobId: string }>();
+  const { jobId } = useParams<{ jobId: string }>();
   const [scriptValue, setScriptValue] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const fiaApiUrl = process.env.REACT_APP_FIA_REST_API_URL;

--- a/src/ValueEditor.tsx
+++ b/src/ValueEditor.tsx
@@ -194,7 +194,7 @@ const ValueEditor: React.FC = () => {
             >
               {runnerVersions.map((version) => (
                 <option key={version} value={version}>
-                  {version}
+                  Mantid {version}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
Closes #351, closes #375.

## Description

Enables the rerun button on the reduction history page and the value editor page.

Fetches the package versions from the Mantid repo (this will require a GitHub token).

Adds snackbar alerts.

Fixes bug where reduction scripts weren't being fetched from the API.