### PR TITLE
Add as user toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express": "4.21.1",
     "express-ws": "5.0.2",
     "i18next": "^24.0.2",
+    "jwt-decode": "^4.0.0",
     "loglevel": "1.9.2",
     "monaco-editor": "^0.52.0",
     "react": "17.0.2",

--- a/src/Jobs/JobsAll.tsx
+++ b/src/Jobs/JobsAll.tsx
@@ -27,12 +27,13 @@ const JobsAll: React.FC = () => {
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc'); // Sorting order (ascending/descending)
   const [selectedInstrument, setSelectedInstrument] = useState(instrumentName || 'ALL'); // Selected instrument filter
   const [orderBy, setOrderBy] = useState<string>('run_start'); // Column to sort by
+  const [asUser, setAsUser] = useState<boolean>(false);
 
   // Calculate the offset for API query based on current page
   const offset = currentPage * rowsPerPage;
 
   // Construct API query string with pagination and sorting parameters
-  const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_run=true`;
+  const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_run=true&as_user=${asUser}`;
 
   // Fetch job data and total count using custom hooks
   const fetchJobs = useFetchJobs(`/jobs`, query, setJobs);
@@ -89,6 +90,8 @@ const JobsAll: React.FC = () => {
         </TableCell>
       )}
       maxHeight={650} // Limit table height
+      asUser={asUser}
+      handleToggleAsUser={(event) => setAsUser(event.target.checked)}
     />
   );
 };

--- a/src/Jobs/JobsAll.tsx
+++ b/src/Jobs/JobsAll.tsx
@@ -27,7 +27,11 @@ const JobsAll: React.FC = () => {
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc'); // Sorting order (ascending/descending)
   const [selectedInstrument, setSelectedInstrument] = useState(instrumentName || 'ALL'); // Selected instrument filter
   const [orderBy, setOrderBy] = useState<string>('run_start'); // Column to sort by
-  const [asUser, setAsUser] = useState<boolean>(false);
+  const [asUser, setAsUser] = useState<boolean>(() => {
+    // Whether to display jobs as a user or not
+    const storedValue = localStorage.getItem('asUser');
+    return storedValue ? JSON.parse(storedValue) : false; // Default to false
+  });
 
   // Calculate the offset for API query based on current page
   const offset = currentPage * rowsPerPage;
@@ -38,6 +42,12 @@ const JobsAll: React.FC = () => {
   // Fetch job data and total count using custom hooks
   const fetchJobs = useFetchJobs(`/jobs`, query, setJobs);
   const fetchTotalCount = useFetchTotalCount(`/jobs/count`, setTotalRows);
+
+  const handleToggleAsUser = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const newValue = event.target.checked;
+    setAsUser(newValue);
+    localStorage.setItem('asUser', JSON.stringify(newValue)); // Save to localStorage
+  };
 
   return (
     <JobsBase
@@ -91,7 +101,7 @@ const JobsAll: React.FC = () => {
       )}
       maxHeight={650} // Limit table height
       asUser={asUser}
-      handleToggleAsUser={(event) => setAsUser(event.target.checked)}
+      handleToggleAsUser={handleToggleAsUser}
     />
   );
 };

--- a/src/Jobs/JobsBase.tsx
+++ b/src/Jobs/JobsBase.tsx
@@ -11,6 +11,7 @@ import {
   Collapse,
   Drawer,
   FormControl,
+  FormControlLabel,
   IconButton,
   InputLabel,
   MenuItem,
@@ -18,6 +19,7 @@ import {
   Select,
   SelectChangeEvent,
   Snackbar,
+  Switch,
   Table,
   TableBody,
   TableCell,
@@ -139,6 +141,8 @@ interface JobsBaseProps {
   fetchTotalCount: () => Promise<void>;
   maxHeight?: number;
   showConfigButton?: boolean;
+  asUser: boolean;
+  handleToggleAsUser: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const JobsBase: React.FC<JobsBaseProps> = ({
@@ -160,6 +164,8 @@ const JobsBase: React.FC<JobsBaseProps> = ({
   fetchTotalCount,
   maxHeight = 624,
   showConfigButton = false,
+  asUser,
+  handleToggleAsUser,
 }) => {
   const theme = useTheme();
   const allInstruments = [{ name: 'ALL' }, ...instruments]; // Add 'ALL' option to the instruments list
@@ -702,6 +708,14 @@ const JobsBase: React.FC<JobsBaseProps> = ({
               Config
             </Button>
           )}
+          <FormControlLabel
+            control={<Switch checked={asUser} onChange={handleToggleAsUser} color="warning" />}
+            label={
+              <Typography variant="body1" color={theme.palette.text.primary}>
+                View as user
+              </Typography>
+            }
+          />
           {handleInstrumentChange && (
             <FormControl style={{ width: '200px', marginLeft: '20px' }}>
               <InputLabel id="instrument-select-label">Instrument</InputLabel>

--- a/src/Jobs/JobsGeneral.tsx
+++ b/src/Jobs/JobsGeneral.tsx
@@ -28,7 +28,11 @@ const JobsGeneral: React.FC = () => {
   const [rowsPerPage, setRowsPerPage] = useState(25); // Number of rows displayed per page
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc'); // Sorting order (ascending/descending)
   const [orderBy, setOrderBy] = useState<string>('run_start'); // Column to sort by
-  const [asUser, setAsUser] = useState<boolean>(false);
+  const [asUser, setAsUser] = useState<boolean>(() => {
+    // Whether to display jobs as a user or not
+    const storedValue = localStorage.getItem('asUser');
+    return storedValue ? JSON.parse(storedValue) : false; // Default to false
+  });
 
   // Calculate the offset for API query based on current page
   const offset = currentPage * rowsPerPage;
@@ -39,6 +43,12 @@ const JobsGeneral: React.FC = () => {
   // Fetch job data and total count using custom hooks
   const fetchJobs = useFetchJobs(`/instrument/${selectedInstrument}/jobs`, query, setJobs);
   const fetchTotalCount = useFetchTotalCount(`/instrument/${selectedInstrument}/jobs/count`, setTotalRows);
+
+  const handleToggleAsUser = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const newValue = event.target.checked;
+    setAsUser(newValue);
+    localStorage.setItem('asUser', JSON.stringify(newValue)); // Save to localStorage
+  };
 
   return (
     <JobsBase
@@ -70,7 +80,7 @@ const JobsGeneral: React.FC = () => {
       fetchTotalCount={fetchTotalCount}
       showConfigButton={selectedInstrument === 'LOQ' || selectedInstrument === 'MARI'} // Show config button only for specific instruments
       asUser={asUser}
-      handleToggleAsUser={(event) => setAsUser(event.target.checked)}
+      handleToggleAsUser={handleToggleAsUser}
     >
       {/* Link to view reductions for all instruments */}
       <Typography

--- a/src/Jobs/JobsGeneral.tsx
+++ b/src/Jobs/JobsGeneral.tsx
@@ -28,12 +28,13 @@ const JobsGeneral: React.FC = () => {
   const [rowsPerPage, setRowsPerPage] = useState(25); // Number of rows displayed per page
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc'); // Sorting order (ascending/descending)
   const [orderBy, setOrderBy] = useState<string>('run_start'); // Column to sort by
+  const [asUser, setAsUser] = useState<boolean>(false);
 
   // Calculate the offset for API query based on current page
   const offset = currentPage * rowsPerPage;
 
   // Construct API query string with pagination and sorting parameters
-  const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_run=true`;
+  const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_run=true&as_user=${asUser}`;
 
   // Fetch job data and total count using custom hooks
   const fetchJobs = useFetchJobs(`/instrument/${selectedInstrument}/jobs`, query, setJobs);
@@ -68,6 +69,8 @@ const JobsGeneral: React.FC = () => {
       fetchJobs={fetchJobs}
       fetchTotalCount={fetchTotalCount}
       showConfigButton={selectedInstrument === 'LOQ' || selectedInstrument === 'MARI'} // Show config button only for specific instruments
+      asUser={asUser}
+      handleToggleAsUser={(event) => setAsUser(event.target.checked)}
     >
       {/* Link to view reductions for all instruments */}
       <Typography

--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,6 +7836,7 @@ __metadata:
     html-webpack-plugin: ^5.6.3
     husky: 9.1.7
     i18next: ^24.0.2
+    jwt-decode: ^4.0.0
     lint-staged: 15.2.10
     loglevel: 1.9.2
     monaco-editor: ^0.52.0
@@ -10568,6 +10569,13 @@ __metadata:
     object.assign: ^4.1.4
     object.values: ^1.1.6
   checksum: f4b05fa4d7b5234230c905cfa88d36dc8a58a6666975a3891429b1a8cdc8a140bca76c297225cb7a499fad25a2c052ac93934449a2c31a44fc9edd06c773780a
+  languageName: node
+  linkType: hard
+
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 390e2edcb31a92e86c8cbdd1edeea4c0d62acd371f8a8f0a8878e499390c0ecf4c658b365c4e941e4ef37d0170e4ca650aaa49f99a45c0b9695a235b210154b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #355, closes #356, closes #359, closes #360.

## Description

Adds an "as user" toggle to the reductions page for staff members. It sets the `as_user` parameter to `true` for jobs requests when toggled on.