### PR TITLE
Fix rows per page bug

### DIFF
--- a/src/components/jobs/JobTable.tsx
+++ b/src/components/jobs/JobTable.tsx
@@ -86,7 +86,13 @@ const JobTable: React.FC<{
             page={currentPage}
             onPageChange={(_, newPage) => handlePageChange(newPage)}
             rowsPerPage={rowsPerPage}
-            onRowsPerPageChange={(e) => setRowsPerPage(parseInt(e.target.value, 10))}
+            onRowsPerPageChange={(e) => {
+              // Prevents the offset from going out of range and showing an empty table
+              const newRowsPerPage = parseInt(e.target.value, 10);
+              const newPage = Math.floor((currentPage * rowsPerPage) / newRowsPerPage);
+              setRowsPerPage(newRowsPerPage);
+              handlePageChange(newPage);
+            }}
           />
         </Box>
         <FilterContainer


### PR DESCRIPTION
Closes #482.

## Description

Fixes bug where the table shows no jobs because the offset is more than the number of runs. This got refactored out by the fuzzy sorting PR so adding it back in.