### PR TITLE
Fix checkbox selections

### DIFF
--- a/src/components/jobs/JobTable.tsx
+++ b/src/components/jobs/JobTable.tsx
@@ -47,7 +47,21 @@ const JobTable: React.FC<{
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
   const [orderBy, setOrderBy] = useState<string>('run_start');
   const offset = currentPage * rowsPerPage;
-  const [filters, setFilters] = useState<JobQueryFilters>({});
+
+  const [filters, setFiltersState] = useState<JobQueryFilters>({});
+  const previousFilters = useRef<JobQueryFilters>({});
+
+  const setFilters = (newFilters: JobQueryFilters): void => {
+    const prev = previousFilters.current;
+    const filtersChanged = JSON.stringify(prev) !== JSON.stringify(newFilters);
+
+    if (filtersChanged) {
+      previousFilters.current = newFilters;
+      setSelectedJobIds([]);
+      setFiltersState(newFilters);
+    }
+  };
+
   const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_run=true&filters=${JSON.stringify(filters)}&as_user=${asUser}`;
   const countQuery = `filters=${JSON.stringify(filters)}`;
   const queryPath = selectedInstrument === 'ALL' ? '/jobs' : `/instrument/${selectedInstrument}/jobs`;


### PR DESCRIPTION
Closes #499.

## Description

To avoid unpredictable behaviour when using the checkboxes and subsequent bulk rerun / download buttons, any interaction that manipulates the table deselects all of the checkboxes.

## How to test:

Essentially, select some random runs using the checkbox feature and then manipulate the table in some way e.g. change page, switch instrument, reduce the number of rows per page, add filters. And see if this results in the checkboxes being unchecked.
