### PR TITLE
Add loading interface

### DIFF
--- a/src/components/jobs/JobTable.tsx
+++ b/src/components/jobs/JobTable.tsx
@@ -47,7 +47,21 @@ const JobTable: React.FC<{
   const [orderDirection, setOrderDirection] = useState<'asc' | 'desc'>('desc');
   const [orderBy, setOrderBy] = useState<string>('run_start');
   const offset = currentPage * rowsPerPage;
-  const [filters, setFilters] = useState<JobQueryFilters>({});
+
+  const [filters, setFiltersState] = useState<JobQueryFilters>({});
+  const previousFilters = useRef<JobQueryFilters>({});
+
+  const setFilters = (newFilters: JobQueryFilters): void => {
+    const prev = previousFilters.current;
+    const filtersChanged = JSON.stringify(prev) !== JSON.stringify(newFilters);
+
+    if (filtersChanged) {
+      previousFilters.current = newFilters;
+      setSelectedJobIds([]);
+      setFiltersState(newFilters);
+    }
+  };
+
   const query = `limit=${rowsPerPage}&offset=${offset}&order_by=${orderBy}&order_direction=${orderDirection}&include_run=true&filters=${JSON.stringify(filters)}&as_user=${asUser}`;
   const countQuery = `filters=${JSON.stringify(filters)}`;
   const queryPath = selectedInstrument === 'ALL' ? '/jobs' : `/instrument/${selectedInstrument}/jobs`;

--- a/src/components/jobs/JobTable.tsx
+++ b/src/components/jobs/JobTable.tsx
@@ -276,8 +276,10 @@ const JobTable: React.FC<{
               rowsPerPage={rowsPerPage}
               slotProps={{
                 actions: {
-                  previousButton: { disabled: isLoading },
-                  nextButton: { disabled: isLoading || currentPage >= Math.ceil(totalRows / rowsPerPage) - 1 },
+                  previousButton: { disabled: isLoading || currentPage === 0 },
+                  nextButton: {
+                    disabled: isLoading || currentPage >= Math.ceil(totalRows / rowsPerPage) - 1,
+                  },
                 },
               }}
               labelRowsPerPage="Rows per page"

--- a/src/components/jobs/JobTable.tsx
+++ b/src/components/jobs/JobTable.tsx
@@ -98,10 +98,10 @@ const JobTable: React.FC<{
   }, [asUser, currentPage, selectedInstrument]);
 
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
+    let timeoutId: number;
 
     if (!isLoading && jobs.length === 0) {
-      timeoutId = setTimeout(() => {
+      timeoutId = window.setTimeout(() => {
         setDelayPassed(true);
       }, 500);
     } else {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -9,11 +9,12 @@ export const useFetchJobs = (
   setJobs: React.Dispatch<React.SetStateAction<Job[]>>
 ): (() => Promise<void>) => {
   return useCallback(async () => {
-    fiaApi
-      .get(`${apiPath}?${queryParams}`)
-      .then((res) => res.data)
-      .then((jobs) => setJobs(jobs))
-      .catch((err) => console.error('Error fetching jobs:', err));
+    try {
+      const res = await fiaApi.get(`${apiPath}?${queryParams}`);
+      setJobs(res.data);
+    } catch (err) {
+      console.error('Error fetching jobs:', err);
+    }
   }, [apiPath, queryParams, setJobs]);
 };
 
@@ -23,9 +24,11 @@ export const useFetchTotalCount = (
   setTotalRows: React.Dispatch<React.SetStateAction<number>>
 ): (() => Promise<void>) => {
   return useCallback(async () => {
-    fiaApi
-      .get(`${apiPath}?${query}`)
-      .then((res) => setTotalRows(res.data.count))
-      .catch((err) => console.error('Error fetching row count', err.message));
+    try {
+      const res = await fiaApi.get(`${apiPath}?${query}`);
+      setTotalRows(res.data.count);
+    } catch (err) {
+      console.error('Error fetching row count:', err);
+    }
   }, [apiPath, setTotalRows, query]);
 };


### PR DESCRIPTION
Closes #501, closes #502, closes #503, closes #504.

## Description

501: Adds a loading skeleton when navigating the reduction table, lets the user know that the data is being fetched prior to being displayed.

502: Collapses rows when the table updates.

503: Maintains table shape when no reductions are found.

504: Removes double scrollbar from reduction history page.


