### PR TITLE
Update URL pathing for easier breadcrumbing

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,5 @@
   "trailingComma": "es5",
   "printWidth": 120,
   "tabWidth": 2,
-  "endOfLine": "auto"
+  "endOfLine": "crlf"
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "eject": "react-scripts eject",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "run-frontend": "yarn build && cd ../scigateway && yarn start"
+    "run-frontend": "yarn build && cd ../scigateway && yarn start",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,10 +67,13 @@ const App: FC = () => {
             <Route path="/instruments">
               <Instruments />
             </Route>
-            <Route path="/reduction-history/:instrumentName">
+            <Route exact path="/reduction-history">
               <JobsPage />
             </Route>
-            <Route path="/value-editor/:jobId">
+            <Route exact path="/reduction-history/:instrumentName">
+              <JobsPage />
+            </Route>
+            <Route path="/reduction-history/:instrumentName/value-editor/:jobId">
               <ValueEditor />
             </Route>
           </Switch>

--- a/src/components/jobs/Row.tsx
+++ b/src/components/jobs/Row.tsx
@@ -671,7 +671,7 @@ const Row: React.FC<{
                     }}
                   >
                     <Link
-                      to={`/value-editor/${job.id}`}
+                      to={`/reduction-history/${job.run.instrument_name}/value-editor/${job.id}`}
                       onClick={() =>
                         ReactGA.event({
                           category: 'Button',

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-    'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,7 +65,7 @@ createRoute(
   false // whether the link should be visible to unauthenticated users
 );
 createRoute('Reductions', 'Instruments', '/fia/instruments', 2, 'Data help text', false);
-createRoute('Reductions', 'Reduction history', '/fia/reduction-history/ALL', 3, 'Data help text', false);
+createRoute('Reductions', 'Reduction history', '/fia/reduction-history', 3, 'Data help text', false);
 
 // Single-SPA bootstrap methods have no idea what type of inputs may be
 // pushed down from the parent app

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -299,7 +299,7 @@ const HomePage = (): React.ReactElement => {
                     color="primary"
                     variant="contained"
                     component={Link}
-                    to={t('reduction-history/ALL')}
+                    to="/reduction-history"
                     data-testid="browse-button"
                   >
                     {t('Browse reductions')}

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -9,7 +9,7 @@ import { jwtDecode } from 'jwt-decode';
 import IMATView from '../components/IMAT/IMATView';
 
 const JobsPage: React.FC = (): ReactElement => {
-  const { instrumentName } = useParams<{ instrumentName: string }>();
+  const { instrumentName } = useParams<{ instrumentName?: string }>();
   const history = useHistory();
   const [selectedInstrument, setSelectedInstrument] = React.useState<string>(instrumentName || 'ALL');
   const theme = useTheme();
@@ -23,7 +23,7 @@ const JobsPage: React.FC = (): ReactElement => {
   const handleInstrumentChange = (event: SelectChangeEvent<string>): void => {
     const newInstrument = event.target.value;
     setSelectedInstrument(newInstrument);
-    history.push(`/reduction-history/${newInstrument}`);
+    history.push(newInstrument === 'ALL' ? `/reduction-history` : `/reduction-history/${newInstrument}`);
   };
   const getUserRole = (): 'staff' | 'user' | null => {
     const token = localStorage.getItem('scigateway:token');
@@ -60,7 +60,7 @@ const JobsPage: React.FC = (): ReactElement => {
               <Typography
                 variant="body1"
                 component={Link}
-                to="/reduction-history/ALL"
+                to="/reduction-history"
                 sx={{
                   color: theme.palette.mode === 'dark' ? '#86b4ff' : theme.palette.primary.main,
                   display: 'flex',

--- a/src/pages/ValueEditor.tsx
+++ b/src/pages/ValueEditor.tsx
@@ -56,7 +56,9 @@ const ValueEditor: React.FC = () => {
       history.goBack();
       return;
     }
-    const fallback = location.state?.from ?? `/reduction-history/${instrumentName ?? 'ALL'}`;
+    const fallback =
+      location.state?.from ??
+      (instrumentName && instrumentName !== 'ALL' ? `/reduction-history/${instrumentName}` : '/reduction-history');
     history.push(fallback);
   };
 


### PR DESCRIPTION
Closes # <!-- Issue # here -->

## Description

Updates the routes to make more sense. The "all" reduction page is just `reduction-history/` now. The value editor page now branches off as follows `reduction-history/{instrument}/value-editor/{job_id}`.