### PR TITLE
Refactor runner version handling in ValueEditor

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 export const reductionStates = ['ERROR', 'UNSUCCESSFUL', 'SUCCESSFUL', 'NOT_STARTED'] as const;
+
 export type ReductionState = (typeof reductionStates)[number];
 
 export interface Job {
@@ -30,7 +31,6 @@ export interface Job {
   };
 }
 
-// if this needs exporting, move it to types
 export interface JobQueryFilters {
   experiment_number_in?: number[];
   title?: string;
@@ -48,3 +48,5 @@ export interface JobQueryFilters {
   experiment_number_after?: number;
   experiment_number_before?: number;
 }
+
+export type RunnerVersionMap = Record<string, string>;


### PR DESCRIPTION
Closes #571.

## Description

Updated ValueEditor to use a RunnerVersionMap for runner versions instead of a string array. Improved robustness of runner version fetching and selection, and updated rerun logic to use the correct image reference format. Removed unneeded navigation and back button code. Disabled select element in scenarios where versions can't be fetched.