### PR TITLE
Rename breadcrumbs and make arrows thicker

### DIFF
--- a/src/components/navigation/NavArrows.tsx
+++ b/src/components/navigation/NavArrows.tsx
@@ -27,21 +27,18 @@ const NavArrows: React.FC = () => {
               position: 'relative',
 
               /* Positions breadcrumb */
-              lineHeight: '28px',
-              padding: '0 4px 0 16px',
+              lineHeight: '32px',
+              padding: '4px 10px 4px 20px',
               textAlign: 'center',
 
               /* Add the arrow between breadcrumbs */
               '&:after': {
                 content: '""',
                 position: 'absolute',
-                top: '3px',
-                // half the width/height
-                right: '-11px',
-                // width/height same as lineHeight - 2* top height
-                height: '22px',
-                width: '22px',
-                // change skew to alter how shallow the arrow is
+                top: '6px',
+                right: '-14px',
+                height: '28px',
+                width: '28px',
                 transform: 'scale(0.707) rotate(45deg) skew(15deg,15deg)',
                 zIndex: 1,
                 boxShadow: `2px -2px 0 2px ${theme.palette.background.default}`,
@@ -73,14 +70,14 @@ const NavArrows: React.FC = () => {
           },
           '& li:first-of-type': {
             '& a, p': {
-              paddingLeft: '14px',
+              paddingLeft: '18px',
             },
           },
           '& li:last-of-type': {
             '& a, p': {
               /* Curve the last breadcrumb border */
               borderRadius: '0 5px 5px 0',
-              paddingLeft: '14px',
+              paddingLeft: '18px',
               '&:after': {
                 content: 'none',
               },

--- a/src/components/navigation/NavArrows.tsx
+++ b/src/components/navigation/NavArrows.tsx
@@ -17,6 +17,8 @@ const NavArrows: React.FC = () => {
         aria-label="breadcrumb"
         separator=""
         sx={(theme) => ({
+          marginTop: theme.spacing(2),
+          marginLeft: theme.spacing(2),
           backgroundColor: theme.palette.background.default,
           '& li': {
             '& a, p': {

--- a/src/pages/Instruments.tsx
+++ b/src/pages/Instruments.tsx
@@ -10,7 +10,7 @@ import StarIcon from '@mui/icons-material/Star';
 
 // Local data
 import { instruments } from '../lib/InstrumentData';
-import NavArrows from '../components/navigation/Breadcrumbs';
+import NavArrows from '../components/navigation/NavArrows';
 
 const Instruments: React.FC = () => {
   const theme = useTheme();

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -4,7 +4,7 @@ import { Box, Button, FormControlLabel, SelectChangeEvent, Switch, Typography, u
 import { ArrowBack, Settings } from '@mui/icons-material';
 import React, { ReactElement, useState } from 'react';
 import InstrumentSelector from '../components/jobs/InstrumentSelector';
-import NavArrows from '../components/navigation/Breadcrumbs';
+import NavArrows from '../components/navigation/NavArrows';
 import InstrumentConfigDrawer from '../components/configsettings/InstrumentConfigDrawer';
 import { jwtDecode } from 'jwt-decode';
 import IMATView from '../components/IMAT/IMATView';

--- a/src/pages/ValueEditor.tsx
+++ b/src/pages/ValueEditor.tsx
@@ -9,7 +9,7 @@ import { Alert, Box, Button, CircularProgress, Snackbar, Tab, Tabs, Typography, 
 import Editor from '@monaco-editor/react';
 import { fiaApi } from '../lib/api';
 
-import NavArrows from '../components/navigation/Breadcrumbs';
+import NavArrows from '../components/navigation/NavArrows';
 import { MantidVersionMap } from '../lib/types';
 
 interface TabPanelProps {


### PR DESCRIPTION
Closes #579.

## Description

Makes the breadcrumbs thicker.

Renames `Breadcrumbs.tsx` file to `NavArrows.tsx` to match component name.
