### PR TITLE
Upgrade to React 18 and Scigateway v3.0.0

### DIFF
--- a/.github/workflows/build-push-action.yml
+++ b/.github/workflows/build-push-action.yml
@@ -35,14 +35,14 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:${{ github.sha }}
 
-      # - name: Build and push scigateway Docker image
-      #   uses: docker/build-push-action@v6
-      #   id: scigateway_build
-      #   with:
-      #     context: ./container
-      #     file: ./container/scigateway.dockerfile
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/scigateway:${{ github.sha }}
+      - name: Build and push scigateway Docker image
+        uses: docker/build-push-action@v6
+        id: scigateway_build
+        with:
+          context: ./container
+          file: ./container/scigateway.dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/scigateway:${{ github.sha }}
 
       - name: Checkout the Gitops repository
         uses: actions/checkout@v5
@@ -55,10 +55,10 @@ jobs:
         with:
           cmd: yq e -i '.spec.template.spec.containers[] |= select(.name == "frontend").image = "ghcr.io/fiaisis/frontend@${{ steps.frontend_build.outputs.digest }}"' './components/frontend/envs/staging/frontend.yml'
 
-      # - name: Edit the YAML scigateway file for staging
-      #   uses: mikefarah/yq@v4.48.1
-      #   with:
-      #     cmd: yq e -i '.spec.template.spec.containers[] |= select(.name == "scigateway").image = "ghcr.io/fiaisis/scigateway@${{ steps.scigateway_build.outputs.digest }}"' './components/scigateway/envs/staging/scigateway.yml'
+      - name: Edit the YAML scigateway file for staging
+        uses: mikefarah/yq@v4.48.1
+        with:
+          cmd: yq e -i '.spec.template.spec.containers[] |= select(.name == "scigateway").image = "ghcr.io/fiaisis/scigateway@${{ steps.scigateway_build.outputs.digest }}"' './components/scigateway/envs/staging/scigateway.yml'
 
       - name: Commit and push changes
         run: |

--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ This repository is for the frontend web application side of [FIA](https://github
 
 ### Downloading the code
 
-To get started developing for the frontend, first you will need to have [Node.js](https://nodejs.org/en/download/package-manager) and [Yarn](https://classic.yarnpkg.com/en/docs/install) installed and set-up on your machine. When following the install wizards just keep to default settings. You will then want to clone the [SciGateway](https://github.com/ral-facilities/scigateway) repository. From now on stick to SciGateway's `release/v2.0.0` branch (worth noting that `develop` is the repository's default branch instead of "main" or "master").
+To get started developing for the frontend, first you will need to have [Node.js](https://nodejs.org/en/download/package-manager) and [Yarn](https://classic.yarnpkg.com/en/docs/install) installed and set-up on your machine. When following the install wizards just keep to default settings. You will then want to clone the [SciGateway](https://github.com/ral-facilities/scigateway) repository. From now on stick to SciGateway's `release/v3.0.0` branch (worth noting that `develop` is the repository's default branch instead of "main" or "master").
 
 With that done, you can now clone the FIA frontend repository.
 
 ### Setting up FIA as a plugin
 
-The frontend works by building the project and then running it through SciGateway as a plugin. You will want to create a `settings.json` file in SciGateway's `public` folder. Do this by simply duplicating [`settings.example.json`](https://github.com/ral-facilities/scigateway/tree/release/v2.0.0/public/settings.example.json) and renaming it. A few adjustments will need to be made, like adding FIA as a plugin, setting `"homepageUrl"` to `"/fia"`, and pointing the `"authUrl"` to `"https://dev.reduce.isis.cclrc.ac.uk/auth"`. The `"auth-provider"` can be set to `null` so login isn't required. Aside from that, keep everything else as is:
+The frontend works by building the project and then running it through SciGateway as a plugin. You will want to create a `settings.json` file in SciGateway's `public` folder. Do this by simply duplicating [`settings.example.json`](https://github.com/ral-facilities/scigateway/tree/release/v3.0.0/public/settings.example.json) and renaming it. A few adjustments will need to be made, like adding FIA as a plugin, setting `"homepageUrl"` to `"/fia"`, and pointing the `"authUrl"` to `"https://dev.reduce.isis.cclrc.ac.uk/auth"`. The `"auth-provider"` can be set to `null` or `"jwt"`. Aside from that, keep everything else as is:
 
 ```json
 // settings.json
-
 "plugins": [
   {
     "name": "fia",
@@ -31,11 +30,10 @@ The frontend works by building the project and then running it through SciGatewa
 ]
 ```
 
-A `dev-plugin-settings.json` file is also needed in SciGateway's `micro-frontend-tools` folder. Like before, simply duplicate [`dev-plugin-settings.example.json`](https://github.com/ral-facilities/scigateway/blob/release/v2.0.0/micro-frontend-tools/dev-plugin-settings.example.json), rename it, and add the path to the FIA frontend build folder:
+A `dev-plugin-settings.json` file is also needed in SciGateway's `micro-frontend-tools` folder. Like before, simply duplicate [`dev-plugin-settings.example.json`](https://github.com/ral-facilities/scigateway/blob/release/v3.0.0/micro-frontend-tools/dev-plugin-settings.example.json), rename it, and add the path to the FIA frontend build folder:
 
 ```json
 // dev-plugin-settings.json
-
 "plugins": [
   {
     "type": "static",

--- a/container/frontend.dockerfile
+++ b/container/frontend.dockerfile
@@ -3,9 +3,9 @@ FROM node:lts-alpine3.19@sha256:ec0c413b1d84f3f7f67ec986ba885930c57b5318d2eb3abc
 
 WORKDIR /app
 
-ENV REACT_APP_FIA_REST_API_URL="/api"
-ENV REACT_APP_FIA_DATA_VIEWER_URL="/data-viewer"
-ENV REACT_APP_PLUGIN_URL="/f-i-a"
+ENV VITE_FIA_REST_API_URL="/api"
+ENV VITE_FIA_DATA_VIEWER_URL="/data-viewer"
+ENV VITE_PLUGIN_URL="/f-i-a"
 
 COPY . .
 
@@ -19,7 +19,7 @@ FROM nginx:stable-alpine3.17-slim@sha256:0a8c5686d40beca3cf231e223668cf77c91344d
 COPY --from=build /app/build /usr/share/nginx/html
 COPY ./container/healthz /usr/share/nginx/html/healthz
 
-ENV REACT_APP_FIA_REST_API_URL="/api"
+ENV VITE_FIA_REST_API_URL="/api"
 
 EXPOSE 80
 

--- a/container/scigateway.dockerfile
+++ b/container/scigateway.dockerfile
@@ -1,11 +1,16 @@
-FROM harbor.stfc.ac.uk/datagateway/scigateway@sha256:3c160722053260cbf89b85a9b1a13356c007e05270086ef77769d2b8f6f8e6d2
-
+FROM harbor.stfc.ac.uk/datagateway/scigateway@sha256:a807d647dfbf183c848bab177b4ae8e503ac7cb784ab717848b6c01b0de6c2a9
 ENV AUTH_URL /auth
 ENV AUTH_PROVIDER jwt
 
 WORKDIR /usr/local/apache2/htdocs
+
+USER root
+# Change the title
+RUN sed -i -e 's/<title>SciGateway<\/title>/<title>FIA<\/title>/' index.html
+USER www-data
+
 COPY --chown=www-data:www-data settings.json ./settings.json
 COPY --chown=www-data:www-data default.json ./res/default.json
 COPY --chown=www-data:www-data images ./res/images
-COPY --chown=www-data:www-data index.html ./index.html
 COPY --chown=www-data:www-data favicon.ico ./favicon.ico
+

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "@mui/x-date-pickers": "^7.27.0",
     "@types/jest": "29.5.14",
     "@types/node": "22.10.0",
-    "@types/react": "17.0.39",
-    "@types/react-dom": "17.0.11",
+    "@types/react": "18.3.11",
+    "@types/react-dom": "18.3.5",
     "axios": "^1.12.0",
     "dayjs": "^1.11.13",
     "express": "4.21.1",
@@ -26,8 +26,8 @@
     "jwt-decode": "^4.0.0",
     "loglevel": "1.9.2",
     "monaco-editor": "^0.52.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "react-ga4": "^2.1.0",
     "react-i18next": "^13.3.1",
     "react-json-pretty": "2.2.0",
@@ -39,7 +39,7 @@
     "ws": "8.18.0"
   },
   "resolutions": {
-    "@types/react": "17.0.39",
+    "@types/react": "18.3.11",
     "@typescript-eslint/eslint-plugin": "8.16.0",
     "@typescript-eslint/parser": "8.16.0"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import ReactDOM from 'react-dom';
+import ReactDOMLegacy from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import React from 'react';
 import './index.css';
 import App from './App';
@@ -10,7 +11,7 @@ import { createWebsocketClient } from './websocket';
 if (import.meta.env.DEV) {
   const el = document.getElementById('fia');
   if (el) {
-    ReactDOM.render(<App />, document.getElementById('fia'));
+    ReactDOMClient.createRoot(el).render(<App />);
   }
   log.setDefaultLevel(log.levels.DEBUG);
 } else {
@@ -29,10 +30,12 @@ function domElementGetter(): HTMLElement {
 // Create WebSocket client to respond to listen for pushed notifications
 createWebsocketClient('ws://localhost:3210/');
 
+const reactDomForSingleSpa = Object.assign({}, ReactDOMLegacy, ReactDOMClient) as typeof ReactDOMLegacy;
+
 const reactLifecycles = singleSpaReact({
   React,
-  ReactDOM,
-  renderType: 'render',
+  ReactDOM: reactDomForSingleSpa,
+  renderType: 'createRoot',
   rootComponent: App,
   domElementGetter,
   errorBoundary: (error): React.ReactElement => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4139,12 +4139,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:17.0.11":
-  version: 17.0.11
-  resolution: "@types/react-dom@npm:17.0.11"
-  dependencies:
-    "@types/react": "*"
-  checksum: 4d5730dffbef86c887cecad7e3cecda424ce6a64d0b5441c63b5b015d48219868660a2bb1aa15e897e565ad8867fa6b885d4358b04e1c4e589ba4c07c3fda55c
+"@types/react-dom@npm:18.3.5":
+  version: 18.3.5
+  resolution: "@types/react-dom@npm:18.3.5"
+  peerDependencies:
+    "@types/react": ^18.0.0
+  checksum: 95c757684f71e761515c5a11299e5feec550c72bb52975487f360e6f0d359b26454c26eaf2ce45dd22748205aa9b2c2fe0abe7005ebcbd233a7615283ac39a7d
   languageName: node
   linkType: hard
 
@@ -4178,14 +4178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:17.0.39":
-  version: 17.0.39
-  resolution: "@types/react@npm:17.0.39"
+"@types/react@npm:18.3.11":
+  version: 18.3.11
+  resolution: "@types/react@npm:18.3.11"
   dependencies:
     "@types/prop-types": "*"
-    "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: bf04d3c2894559012710d595553e12b422d3b91cd8f4f7e122d8cb044ba9c2ba17f6e8a4e09581359cc5509ddc59cd8c8fabd6774f3505a40a45393f074d6e6e
+  checksum: 6cbf36673b64e758dd61b16c24139d015f58530e0d476777de26ba83f24b55e142fbf64e3b8f6b3c7b05ed9ba548551b2a62d9ffb0f95743d0a368646a619163
   languageName: node
   linkType: hard
 
@@ -4202,13 +4201,6 @@ __metadata:
   version: 0.12.0
   resolution: "@types/retry@npm:0.12.0"
   checksum: 61a072c7639f6e8126588bf1eb1ce8835f2cb9c2aba795c4491cf6310e013267b0c8488039857c261c387e9728c1b43205099223f160bb6a76b4374f741b5603
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.23.0
-  resolution: "@types/scheduler@npm:0.23.0"
-  checksum: 874d753aa65c17760dfc460a91e6df24009bde37bfd427a031577b30262f7770c1b8f71a21366c7dbc76111967384cf4090a31d65315155180ef14bd7acccb32
   languageName: node
   linkType: hard
 
@@ -8546,8 +8538,8 @@ __metadata:
     "@mui/x-date-pickers": ^7.27.0
     "@types/jest": 29.5.14
     "@types/node": 22.10.0
-    "@types/react": 17.0.39
-    "@types/react-dom": 17.0.11
+    "@types/react": 18.3.11
+    "@types/react-dom": 18.3.5
     "@types/react-router-dom": 5.3.3
     "@typescript-eslint/eslint-plugin": 8.16.0
     "@typescript-eslint/parser": 8.16.0
@@ -8572,8 +8564,8 @@ __metadata:
     loglevel: 1.9.2
     monaco-editor: ^0.52.0
     prettier: 3.4.1
-    react: 17.0.2
-    react-dom: 17.0.2
+    react: 18.3.1
+    react-dom: 18.3.1
     react-ga4: ^2.1.0
     react-i18next: ^13.3.1
     react-json-pretty: 2.2.0
@@ -14069,16 +14061,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.2
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.3.1
+  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
   languageName: node
   linkType: hard
 
@@ -14300,13 +14291,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
   languageName: node
   linkType: hard
 
@@ -14928,13 +14918,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: 3e82d1f419e240ef6219d794ff29c7ee415fbdc19e038f680a10c067108e06284f1847450a210b29bbaf97b9d8a97ced5f624c31c681248ac84c80d56ad5a2c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #594, closes #593.

## Description

Upgrades to React 18 and points to SciGateway v3.0.0 in the `/container` folder.

## How to test

1. Follow the instructions for https://github.com/fiaisis/fia-auth/pull/160 except be on this branch obviously.
2. Everything should build fine as React 18 has backwards compatibility.
