### PR TITLE
Set fixed width for first column in jobs table

### DIFF
--- a/src/components/jobs/JobTableHead.tsx
+++ b/src/components/jobs/JobTableHead.tsx
@@ -60,9 +60,9 @@ const highlightHover = (theme: Theme): React.CSSProperties => {
         ? theme.palette.primary.dark // Light mode hover colour
         : theme.palette.mode === 'dark'
           ? theme.palette.primary.dark // Dark mode hover colour
-        : theme.palette.primary.dark, // High contrast mode hover colour
-    };
+          : theme.palette.primary.dark, // High contrast mode hover colour
   };
+};
 
 interface JobTableHeadProps {
   selectedInstrument: string;
@@ -79,7 +79,15 @@ const JobTableHead: React.FC<JobTableHeadProps> = ({ selectedInstrument, handleS
   return (
     <TableHead sx={{ '& th': { py: 0.5 }, height: '54px' }}>
       <TableRow>
-        <TableCell sx={{ width: '4%', ...headerStyles(theme) }} align="left"></TableCell>
+        <TableCell
+          sx={{
+            width: '80px',
+            minWidth: '80px',
+            maxWidth: '80px',
+            ...headerStyles(theme),
+          }}
+          align="left"
+        ></TableCell>
         <SortableHeaderCell
           headerName="Experiment number"
           sortKey="experiment_number"

--- a/src/components/jobs/Row.tsx
+++ b/src/components/jobs/Row.tsx
@@ -478,7 +478,15 @@ const Row: React.FC<{
         }}
         onClick={() => setOpen(!open)}
       >
-        <TableCell sx={{ py: 0, px: 1, ...ellipsisWrap }}>
+        <TableCell
+          sx={{
+            py: 0,
+            px: 1,
+            width: '80px',
+            minWidth: '80px',
+            maxWidth: '80px',
+          }}
+        >
           <Box display="flex" alignItems="center" gap={0.5}>
             <Checkbox
               color="primary"


### PR DESCRIPTION
Closes None.

## Description

Updates the styling of the first column in the jobs table to ensure consistent width across both the table header and rows.