### PR TITLE
Refactor and fix md graph

### DIFF
--- a/src/components/experimentViewer/ExperimentSearch.tsx
+++ b/src/components/experimentViewer/ExperimentSearch.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { Box, TextField, Button, Paper, Autocomplete, Typography } from '@mui/material';
+import { Box, TextField, Button, Paper, Autocomplete, Typography, ToggleButtonGroup, ToggleButton } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ClearIcon from '@mui/icons-material/Clear';
 import { instruments } from '../../lib/instrumentData';
 
 interface ExperimentSearchProps {
-  onSearch: (instrumentName: string | null, experimentNumber: number | null) => void;
+  onSearch: (instrumentName: string | null, experimentNumber: number | null, limit: number) => void;
   onClear: () => void;
   initialInstrument?: string;
   initialExperimentNumber?: number;
@@ -25,10 +25,11 @@ const ExperimentSearch: React.FC<ExperimentSearchProps> = ({
   const [experimentNumber, setExperimentNumber] = useState<string>(
     initialExperimentNumber ? initialExperimentNumber.toString() : ''
   );
+  const [resultLimit, setResultLimit] = useState<number>(10);
 
   const handleSearch = (): void => {
     const expNum = experimentNumber.trim() ? parseInt(experimentNumber) : null;
-    onSearch(selectedInstrument, expNum);
+    onSearch(selectedInstrument, expNum, resultLimit);
   };
 
   const handleClear = (): void => {
@@ -97,6 +98,25 @@ const ExperimentSearch: React.FC<ExperimentSearchProps> = ({
             Clear
           </Button>
         )}
+      </Box>
+
+      {/* Result limit selector */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          Results limit:
+        </Typography>
+        <ToggleButtonGroup
+          value={resultLimit}
+          exclusive
+          onChange={(_, newLimit) => newLimit !== null && setResultLimit(newLimit)}
+          size="small"
+          disabled={isLoading}
+        >
+          <ToggleButton value={10}>10</ToggleButton>
+          <ToggleButton value={25}>25</ToggleButton>
+          <ToggleButton value={50}>50</ToggleButton>
+          <ToggleButton value={100}>100</ToggleButton>
+        </ToggleButtonGroup>
       </Box>
 
       {isSearchActive && (selectedInstrument || experimentNumber) && (

--- a/src/components/experimentViewer/ExperimentSearch.tsx
+++ b/src/components/experimentViewer/ExperimentSearch.tsx
@@ -98,12 +98,13 @@ const ExperimentSearch: React.FC<ExperimentSearchProps> = ({
             Clear
           </Button>
         )}
-      </Box>
 
-      {/* Result limit selector */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2 }}>
+        {/* Spacer to push limit controls to the right */}
+        <Box sx={{ flex: 1 }} />
+
+        {/* Result limit selector */}
         <Typography variant="body2" color="text.secondary">
-          Results limit:
+          Limit:
         </Typography>
         <ToggleButtonGroup
           value={resultLimit}

--- a/src/components/experimentViewer/FileCard.tsx
+++ b/src/components/experimentViewer/FileCard.tsx
@@ -1,0 +1,307 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Checkbox,
+  Radio,
+  FormControlLabel,
+  TextField,
+  Select,
+  MenuItem,
+  Chip,
+  Card,
+  CardContent,
+  FormControl,
+  InputLabel,
+  ToggleButton,
+  ToggleButtonGroup,
+} from '@mui/material';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import type { FileConfig } from '../../lib/types';
+
+interface FileCardProps {
+  file: FileConfig;
+  fileIndex: number;
+  filename: string;
+  activeViewerTab: '1d' | '2d';
+  selected2DFile: string | null;
+  inputMode: 'text' | 'chips';
+  onInputModeChange: (mode: 'text' | 'chips') => void;
+  onFileToggle: (index: number) => void;
+  onDatasetChange: (index: number, datasetPath: string) => void;
+  onSelectionChange: (index: number, selections: number[]) => void;
+  onSelect2DFile?: (filename: string) => void;
+}
+
+const FileCard: React.FC<FileCardProps> = ({
+  file,
+  fileIndex,
+  filename,
+  activeViewerTab,
+  selected2DFile,
+  inputMode,
+  onInputModeChange,
+  onFileToggle,
+  onDatasetChange,
+  onSelectionChange,
+  onSelect2DFile,
+}): JSX.Element => {
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        border: file.enabled ? 2 : 1,
+        borderColor: file.enabled ? 'primary.main' : 'divider',
+      }}
+    >
+      <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+        {/* File selection - checkbox in 1D mode, radio in 2D mode */}
+        <FormControlLabel
+          control={
+            activeViewerTab === '2d' ? (
+              <Radio
+                size="small"
+                checked={selected2DFile === filename}
+                onChange={() => onSelect2DFile?.(filename)}
+              />
+            ) : (
+              <Checkbox size="small" checked={file.enabled} onChange={() => onFileToggle(fileIndex)} />
+            )
+          }
+          label={
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <InsertDriveFileIcon fontSize="small" color="action" />
+              <Typography
+                variant="body2"
+                sx={{
+                  wordBreak: 'break-all',
+                  fontSize: '0.8rem',
+                }}
+              >
+                {filename}
+              </Typography>
+            </Box>
+          }
+          sx={{ m: 0, width: '100%', alignItems: 'flex-start' }}
+        />
+
+        {/* File controls - only show in 1D mode if enabled */}
+        {activeViewerTab === '1d' && file.enabled && (
+          <Box sx={{ mt: 2, ml: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {/* Dataset selector - dropdown for discovered datasets */}
+            <Box>
+              {file.isDiscovered && file.discoveredDatasets && file.discoveredDatasets.length > 0 ? (
+                // Show dropdown for discovered datasets
+                <FormControl fullWidth size="small">
+                  <InputLabel id={`dataset-select-label-${fileIndex}`}>
+                    Dataset ({file.discoveredDatasets.length} found)
+                  </InputLabel>
+                  <Select
+                    labelId={`dataset-select-label-${fileIndex}`}
+                    value={file.path || ''}
+                    label={`Dataset (${file.discoveredDatasets.length} found)`}
+                    onChange={(e) => {
+                      if (e.target.value) {
+                        onDatasetChange(fileIndex, e.target.value);
+                      }
+                    }}
+                    displayEmpty
+                    sx={{
+                      fontSize: '0.875rem',
+                    }}
+                  >
+                    {!file.path && (
+                      <MenuItem value="" disabled>
+                        <em>Select a dataset</em>
+                      </MenuItem>
+                    )}
+                    {file.discoveredDatasets.map((dataset) => (
+                      <MenuItem
+                        key={dataset.path}
+                        value={dataset.path}
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'flex-start',
+                          py: 1.5,
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontFamily: 'monospace',
+                            fontSize: '0.75rem',
+                            wordBreak: 'break-all',
+                            mb: 0.5,
+                          }}
+                        >
+                          {dataset.path}
+                        </Typography>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            gap: 0.5,
+                            flexWrap: 'wrap',
+                          }}
+                        >
+                          {dataset.isPrimary && (
+                            <Chip
+                              label="Primary"
+                              size="small"
+                              color="success"
+                              sx={{ height: 18, fontSize: '0.65rem', fontWeight: 600 }}
+                            />
+                          )}
+                          <Chip
+                            label={dataset.shape.join(' × ')}
+                            size="small"
+                            sx={{ height: 18, fontSize: '0.65rem' }}
+                          />
+                          <Chip
+                            label={dataset.is2D ? '2D' : '1D'}
+                            size="small"
+                            color={dataset.is2D ? 'secondary' : 'primary'}
+                            sx={{ height: 18, fontSize: '0.65rem' }}
+                          />
+                          <Chip
+                            label={dataset.dtype.class}
+                            size="small"
+                            sx={{ height: 18, fontSize: '0.65rem' }}
+                          />
+                          {dataset.errorPath && (
+                            <Chip
+                              label="Supports error bars"
+                              size="small"
+                              color="info"
+                              sx={{ height: 18, fontSize: '0.65rem' }}
+                            />
+                          )}
+                        </Box>
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              ) : file.isDiscovered ? (
+                // Datasets discovered but none found
+                <Box sx={{ textAlign: 'center', py: 2 }}>
+                  <Typography variant="caption" sx={{ fontStyle: 'italic' }}>
+                    No numeric datasets found
+                  </Typography>
+                </Box>
+              ) : (
+                // Discovering datasets
+                <Box sx={{ textAlign: 'center', py: 2 }}>
+                  <Typography variant="caption" sx={{ fontStyle: 'italic' }}>
+                    Discovering datasets...
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+
+            {/* Selection input - only for 2D datasets being sliced to 1D */}
+            {file.path && file.selectedDatasetIs2D && (
+              <Box>
+                {/* Mode toggle */}
+                <Box
+                  sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
+                >
+                  <Typography variant="body2" fontWeight="500">
+                    Slice Selection (2D → 1D)
+                  </Typography>
+                  <ToggleButtonGroup
+                    size="small"
+                    value={inputMode}
+                    exclusive
+                    onChange={(_, newMode) => newMode && onInputModeChange(newMode)}
+                    sx={{ height: 24 }}
+                  >
+                    <ToggleButton value="text" sx={{ px: 1, py: 0.5, fontSize: '0.75rem' }}>
+                      Text
+                    </ToggleButton>
+                    <ToggleButton value="chips" sx={{ px: 1, py: 0.5, fontSize: '0.75rem' }}>
+                      Chips
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+                </Box>
+
+                {/* Text input mode */}
+                {inputMode === 'text' && (
+                  <TextField
+                    size="small"
+                    value={file.selection?.join(',') || ''}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (value === '') {
+                        onSelectionChange(fileIndex, []);
+                      } else {
+                        const selections = value
+                          .split(',')
+                          .map((s) => parseInt(s.trim()))
+                          .filter((n) => !isNaN(n) && n >= 0);
+                        onSelectionChange(fileIndex, selections);
+                      }
+                    }}
+                    placeholder="7,8"
+                    fullWidth
+                    sx={{
+                      '& .MuiInputBase-input': {
+                        fontSize: '0.875rem',
+                      },
+                    }}
+                    helperText="Comma-separated indices (each slice fetched separately)"
+                  />
+                )}
+
+                {/* Chip-based input mode */}
+                {inputMode === 'chips' && (
+                  <Box>
+                    <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 1, minHeight: 32 }}>
+                      {(file.selection || []).map((slice, idx) => (
+                        <Chip
+                          key={idx}
+                          label={`Slice ${slice}`}
+                          onDelete={() => {
+                            const newSelections = file.selection?.filter((_, i) => i !== idx) || [];
+                            onSelectionChange(fileIndex, newSelections);
+                          }}
+                          size="small"
+                          sx={{ fontSize: '0.75rem' }}
+                        />
+                      ))}
+                    </Box>
+                    <TextField
+                      size="small"
+                      type="number"
+                      placeholder="Add slice"
+                      slotProps={{ htmlInput: { min: 0 } }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          const input = e.target as HTMLInputElement;
+                          const value = parseInt(input.value);
+                          if (!isNaN(value) && value >= 0) {
+                            const newSelections = [...(file.selection || []), value];
+                            onSelectionChange(fileIndex, newSelections);
+                            input.value = '';
+                          }
+                        }
+                      }}
+                      fullWidth
+                      sx={{
+                        '& .MuiInputBase-input': {
+                          fontSize: '0.875rem',
+                        },
+                      }}
+                      helperText="Press Enter to add slice"
+                    />
+                  </Box>
+                )}
+              </Box>
+            )}
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FileCard;

--- a/src/components/experimentViewer/FileTree.tsx
+++ b/src/components/experimentViewer/FileTree.tsx
@@ -3,28 +3,16 @@ import {
   Box,
   Typography,
   Checkbox,
-  Radio,
   FormControlLabel,
-  TextField,
-  Select,
-  MenuItem,
   Chip,
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Card,
-  CardContent,
   Tooltip,
-  FormControl,
-  InputLabel,
-  ToggleButton,
-  ToggleButtonGroup,
-  InputAdornment,
 } from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FolderIcon from '@mui/icons-material/Folder';
-import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import FileCard from './FileCard';
 import type { FileConfig, Job } from '../../lib/types';
 
 interface FileTreeProps {
@@ -55,10 +43,6 @@ const FileTree: React.FC<FileTreeProps> = ({
   const [expandedJobs, setExpandedJobs] = useState<Set<number>>(new Set());
   const [showEmptyJobs, setShowEmptyJobs] = useState(false);
   const [inputMode, setInputMode] = useState<'text' | 'chips'>('text');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [resultLimit, setResultLimit] = useState(10);
-
-  console.log('FileTree rendered with files:', files);
 
   // Helper to find file config by filename
   const getFileConfig = (filename: string): FileConfig | undefined => {
@@ -222,261 +206,20 @@ const FileTree: React.FC<FileTreeProps> = ({
                 if (!file) return null;
 
                 return (
-                  <Card
+                  <FileCard
                     key={outputIndex}
-                    variant="outlined"
-                    sx={{
-                      border: file.enabled ? 2 : 1,
-                      borderColor: file.enabled ? 'primary.main' : 'divider',
-                    }}
-                  >
-                    <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-                      {/* File selection - checkbox in 1D mode, radio in 2D mode */}
-                      <FormControlLabel
-                        control={
-                          activeViewerTab === '2d' ? (
-                            <Radio
-                              size="small"
-                              checked={selected2DFile === output}
-                              onChange={() => onSelect2DFile?.(output)}
-                            />
-                          ) : (
-                            <Checkbox size="small" checked={file.enabled} onChange={() => onFileToggle(fileIndex)} />
-                          )
-                        }
-                        label={
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            <InsertDriveFileIcon fontSize="small" color="action" />
-                            <Typography
-                              variant="body2"
-                              sx={{
-                                wordBreak: 'break-all',
-                                fontSize: '0.8rem',
-                              }}
-                            >
-                              {output}
-                            </Typography>
-                          </Box>
-                        }
-                        sx={{ m: 0, width: '100%', alignItems: 'flex-start' }}
-                      />
-
-                      {/* File controls - only show in 1D mode if enabled */}
-                      {activeViewerTab === '1d' && file.enabled && (
-                        <Box sx={{ mt: 2, ml: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
-                          {/* Dataset selector - dropdown for discovered datasets */}
-                          <Box>
-                            {file.isDiscovered && file.discoveredDatasets && file.discoveredDatasets.length > 0 ? (
-                              // Show dropdown for discovered datasets
-                              <FormControl fullWidth size="small">
-                                <InputLabel id={`dataset-select-label-${fileIndex}`}>
-                                  Dataset ({file.discoveredDatasets.length} found)
-                                </InputLabel>
-                                <Select
-                                  labelId={`dataset-select-label-${fileIndex}`}
-                                  value={file.path || ''}
-                                  label={`Dataset (${file.discoveredDatasets.length} found)`}
-                                  onChange={(e) => {
-                                    if (e.target.value) {
-                                      onDatasetChange(fileIndex, e.target.value);
-                                    }
-                                  }}
-                                  displayEmpty
-                                  sx={{
-                                    fontSize: '0.875rem',
-                                  }}
-                                >
-                                  {!file.path && (
-                                    <MenuItem value="" disabled>
-                                      <em>Select a dataset</em>
-                                    </MenuItem>
-                                  )}
-                                  {file.discoveredDatasets.map((dataset) => (
-                                    <MenuItem
-                                      key={dataset.path}
-                                      value={dataset.path}
-                                      sx={{
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        alignItems: 'flex-start',
-                                        py: 1.5,
-                                      }}
-                                    >
-                                      <Typography
-                                        variant="body2"
-                                        sx={{
-                                          fontFamily: 'monospace',
-                                          fontSize: '0.75rem',
-                                          wordBreak: 'break-all',
-                                          mb: 0.5,
-                                        }}
-                                      >
-                                        {dataset.path}
-                                      </Typography>
-                                      <Box
-                                        sx={{
-                                          display: 'flex',
-                                          gap: 0.5,
-                                          flexWrap: 'wrap',
-                                        }}
-                                      >
-                                        {dataset.isPrimary && (
-                                          <Chip
-                                            label="Primary"
-                                            size="small"
-                                            color="success"
-                                            sx={{ height: 18, fontSize: '0.65rem', fontWeight: 600 }}
-                                          />
-                                        )}
-                                        <Chip
-                                          label={dataset.shape.join(' × ')}
-                                          size="small"
-                                          sx={{ height: 18, fontSize: '0.65rem' }}
-                                        />
-                                        <Chip
-                                          label={dataset.is2D ? '2D' : '1D'}
-                                          size="small"
-                                          color={dataset.is2D ? 'secondary' : 'primary'}
-                                          sx={{ height: 18, fontSize: '0.65rem' }}
-                                        />
-                                        <Chip
-                                          label={dataset.dtype.class}
-                                          size="small"
-                                          sx={{ height: 18, fontSize: '0.65rem' }}
-                                        />
-                                        {dataset.errorPath && (
-                                          <Chip
-                                            label="Supports error bars"
-                                            size="small"
-                                            color="info"
-                                            sx={{ height: 18, fontSize: '0.65rem' }}
-                                          />
-                                        )}
-                                      </Box>
-                                    </MenuItem>
-                                  ))}
-                                </Select>
-                              </FormControl>
-                            ) : file.isDiscovered ? (
-                              // Datasets discovered but none found
-                              <Box sx={{ textAlign: 'center', py: 2 }}>
-                                <Typography variant="caption" sx={{ fontStyle: 'italic' }}>
-                                  No numeric datasets found
-                                </Typography>
-                              </Box>
-                            ) : (
-                              // Discovering datasets
-                              <Box sx={{ textAlign: 'center', py: 2 }}>
-                                <Typography variant="caption" sx={{ fontStyle: 'italic' }}>
-                                  Discovering datasets...
-                                </Typography>
-                              </Box>
-                            )}
-                          </Box>
-
-                          {/* Selection input - only for 2D datasets being sliced to 1D */}
-                          {file.path && file.selectedDatasetIs2D && (
-                            <Box>
-                              {/* Mode toggle */}
-                              <Box
-                                sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
-                              >
-                                <Typography variant="body2" fontWeight="500">
-                                  Slice Selection (2D → 1D)
-                                </Typography>
-                                <ToggleButtonGroup
-                                  size="small"
-                                  value={inputMode}
-                                  exclusive
-                                  onChange={(e, newMode) => newMode && setInputMode(newMode)}
-                                  sx={{ height: 24 }}
-                                >
-                                  <ToggleButton value="text" sx={{ px: 1, py: 0.5, fontSize: '0.75rem' }}>
-                                    Text
-                                  </ToggleButton>
-                                  <ToggleButton value="chips" sx={{ px: 1, py: 0.5, fontSize: '0.75rem' }}>
-                                    Chips
-                                  </ToggleButton>
-                                </ToggleButtonGroup>
-                              </Box>
-
-                              {/* Text input mode */}
-                              {inputMode === 'text' && (
-                                <TextField
-                                  size="small"
-                                  value={file.selection?.join(',') || ''}
-                                  onChange={(e) => {
-                                    const value = e.target.value;
-                                    if (value === '') {
-                                      onSelectionChange(fileIndex, []);
-                                    } else {
-                                      const selections = value
-                                        .split(',')
-                                        .map((s) => parseInt(s.trim()))
-                                        .filter((n) => !isNaN(n) && n >= 0);
-                                      onSelectionChange(fileIndex, selections);
-                                    }
-                                  }}
-                                  placeholder="7,8"
-                                  fullWidth
-                                  sx={{
-                                    '& .MuiInputBase-input': {
-                                      fontSize: '0.875rem',
-                                    },
-                                  }}
-                                  helperText="Comma-separated indices (each slice fetched separately)"
-                                />
-                              )}
-
-                              {/* Chip-based input mode */}
-                              {inputMode === 'chips' && (
-                                <Box>
-                                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mb: 1, minHeight: 32 }}>
-                                    {(file.selection || []).map((slice, idx) => (
-                                      <Chip
-                                        key={idx}
-                                        label={`Slice ${slice}`}
-                                        onDelete={() => {
-                                          const newSelections = file.selection?.filter((_, i) => i !== idx) || [];
-                                          onSelectionChange(fileIndex, newSelections);
-                                        }}
-                                        size="small"
-                                        sx={{ fontSize: '0.75rem' }}
-                                      />
-                                    ))}
-                                  </Box>
-                                  <TextField
-                                    size="small"
-                                    type="number"
-                                    placeholder="Add slice"
-                                    inputProps={{ min: 0 }} //TODO deprecated
-                                    onKeyDown={(e) => {
-                                      if (e.key === 'Enter') {
-                                        const input = e.target as HTMLInputElement;
-                                        const value = parseInt(input.value);
-                                        if (!isNaN(value) && value >= 0) {
-                                          const newSelections = [...(file.selection || []), value];
-                                          onSelectionChange(fileIndex, newSelections);
-                                          input.value = '';
-                                        }
-                                      }
-                                    }}
-                                    fullWidth
-                                    sx={{
-                                      '& .MuiInputBase-input': {
-                                        fontSize: '0.875rem',
-                                      },
-                                    }}
-                                    helperText="Press Enter to add slice"
-                                  />
-                                </Box>
-                              )}
-                            </Box>
-                          )}
-                        </Box>
-                      )}
-                    </CardContent>
-                  </Card>
+                    file={file}
+                    fileIndex={fileIndex}
+                    filename={output}
+                    activeViewerTab={activeViewerTab}
+                    selected2DFile={selected2DFile}
+                    inputMode={inputMode}
+                    onInputModeChange={setInputMode}
+                    onFileToggle={onFileToggle}
+                    onDatasetChange={onDatasetChange}
+                    onSelectionChange={onSelectionChange}
+                    onSelect2DFile={onSelect2DFile}
+                  />
                 );
               })}
             </Box>

--- a/src/components/experimentViewer/FileTree.tsx
+++ b/src/components/experimentViewer/FileTree.tsx
@@ -19,7 +19,9 @@ import {
   InputLabel,
   ToggleButton,
   ToggleButtonGroup,
+  InputAdornment,
 } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FolderIcon from '@mui/icons-material/Folder';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
@@ -53,6 +55,8 @@ const FileTree: React.FC<FileTreeProps> = ({
   const [expandedJobs, setExpandedJobs] = useState<Set<number>>(new Set());
   const [showEmptyJobs, setShowEmptyJobs] = useState(false);
   const [inputMode, setInputMode] = useState<'text' | 'chips'>('text');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [resultLimit, setResultLimit] = useState(10);
 
   console.log('FileTree rendered with files:', files);
 

--- a/src/components/experimentViewer/Graph.tsx
+++ b/src/components/experimentViewer/Graph.tsx
@@ -18,8 +18,6 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
   const [xScaleType, setXScaleType] = useState<ScaleType.Linear | ScaleType.Log | ScaleType.SymLog>(ScaleType.Linear);
   const [yScaleType, setYScaleType] = useState<ScaleType.Linear | ScaleType.Log | ScaleType.SymLog>(ScaleType.Linear);
 
-  console.log('PlotViewer rendered with data:', linePlotData);
-
   // Handle empty state
   if (linePlotData.length === 0) {
     return (
@@ -49,15 +47,12 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
   const sortedData = [...linePlotData].sort((a, b) => b.data.length - a.data.length);
 
   // Render line plots - largest domain as primary, rest as auxiliaries
-  console.log('Rendering line plots with data:', sortedData);
   const primaryData = sortedData[0];
-  console.log('Primary data:', primaryData.filename, 'data:', primaryData.data);
 
   const primaryArray = ndarray(primaryData.data, [primaryData.data.length]);
 
   // Generate abscissas (x-values) for primary data based on its length
   const primaryAbscissas = Float32Array.from({ length: primaryData.data.length }, (_, i) => i);
-  console.log('Primary abscisaas: ', primaryAbscissas);
 
   // Create error array if available and showErrors is true
   const primaryErrorsArray =
@@ -108,7 +103,6 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
   }
 
   const domain = combinedDomain;
-  console.log('Combined Y-axis domain for scale', yScaleType, ':', domain);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>

--- a/src/components/experimentViewer/Graph.tsx
+++ b/src/components/experimentViewer/Graph.tsx
@@ -44,32 +44,71 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
     );
   }
 
-  // Render line plots - first as primary, rest as auxiliaries
-  console.log('Rendering line plots with data:', linePlotData);
-  const primaryData = linePlotData[0];
+  // Sort data by domain size (largest first) to ensure the file with the biggest domain is primary
+  // This prevents crashes when auxiliary data has a larger domain than primary
+  const sortedData = [...linePlotData].sort((a, b) => b.data.length - a.data.length);
+
+  // Render line plots - largest domain as primary, rest as auxiliaries
+  console.log('Rendering line plots with data:', sortedData);
+  const primaryData = sortedData[0];
   console.log('Primary data:', primaryData.filename, 'data:', primaryData.data);
 
   const primaryArray = ndarray(primaryData.data, [primaryData.data.length]);
 
+  // Generate abscissas (x-values) for primary data based on its length
+  const primaryAbscissas = Float32Array.from({ length: primaryData.data.length }, (_, i) => i);
+  console.log('Primary abscisaas: ', primaryAbscissas);
+
   // Create error array if available and showErrors is true
-  const errorsArray =
+  const primaryErrorsArray =
     showErrors && primaryData.errors ? ndarray(primaryData.errors, [primaryData.errors.length]) : undefined;
 
-  // Calculate Y domain based on Y scale type
-  // getDomain automatically filters out invalid values for log scales:
-  // - For Log scale: excludes negative and zero values
-  // - For SymLog scale: excludes zero values but allows negative
-  // - For Linear scale: includes all values
-  const domain = getDomain(primaryArray, yScaleType, errorsArray);
-  console.log('Y-axis domain for scale', yScaleType, ':', domain);
-
   // Create auxiliaries for additional lines with error bars
-  const auxiliaries = linePlotData.slice(1).map((data) => ({
-    array: ndarray(data.data, [data.data.length]),
-    label: data.filename,
-    color: data.color,
-    errors: showErrors && data.errors ? ndarray(data.errors, [data.errors.length]) : undefined,
-  }));
+  // Pad auxiliary arrays with NaN to match primary length (NaN values won't render)
+  const primaryLength = primaryData.data.length;
+  const auxiliaries = sortedData.slice(1).map((data) => {
+    // Pad data array with NaN if shorter than primary
+    const paddedData = new Float32Array(primaryLength);
+    paddedData.set(data.data);
+    if (data.data.length < primaryLength) {
+      paddedData.fill(NaN, data.data.length);
+    }
+
+    // Pad errors array with NaN if available and shorter than primary
+    let paddedErrors: Float32Array | undefined;
+    if (showErrors && data.errors) {
+      paddedErrors = new Float32Array(primaryLength);
+      paddedErrors.set(data.errors);
+      if (data.errors.length < primaryLength) {
+        paddedErrors.fill(NaN, data.errors.length);
+      }
+    }
+
+    return {
+      array: ndarray(paddedData, [primaryLength]),
+      label: data.filename,
+      color: data.color,
+      errors: paddedErrors ? ndarray(paddedErrors, [primaryLength]) : undefined,
+    };
+  });
+
+  // Calculate combined Y domain across all data to ensure proper graph sizing
+  // Start with primary data domain
+  let combinedDomain = getDomain(primaryArray, yScaleType, primaryErrorsArray);
+
+  // Extend domain to include all auxiliaries
+  for (const aux of auxiliaries) {
+    const auxDomain = getDomain(aux.array, yScaleType, aux.errors);
+    if (auxDomain && combinedDomain) {
+      combinedDomain = [
+        Math.min(combinedDomain[0], auxDomain[0]),
+        Math.max(combinedDomain[1], auxDomain[1]),
+      ];
+    }
+  }
+
+  const domain = combinedDomain;
+  console.log('Combined Y-axis domain for scale', yScaleType, ':', domain);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
@@ -109,12 +148,12 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
       <LineVis
         dataArray={primaryArray}
         domain={domain}
-        errorsArray={errorsArray}
+        errorsArray={primaryErrorsArray}
         showErrors={showErrors}
         auxiliaries={auxiliaries.length > 0 ? auxiliaries : undefined}
         showGrid={lineShowGrid}
         scaleType={yScaleType}
-        abscissaParams={{ scaleType: xScaleType }}
+        abscissaParams={{ scaleType: xScaleType, value: primaryAbscissas }}
       />
     </Box>
   );

--- a/src/components/jobs/Row.tsx
+++ b/src/components/jobs/Row.tsx
@@ -130,20 +130,6 @@ const JobOutput: React.FC<{
               >
                 View
               </Button>
-              {/* Show H5 Viewer button for HDF5 files */}
-              {(output.endsWith('.h5') ||
-                output.endsWith('.hdf5') ||
-                output.endsWith('.nxs') ||
-                output.endsWith('.nxspe')) && (
-                <Button
-                  variant="contained"
-                  component={Link}
-                  to={`/reduction-history/${job.run?.instrument_name || 'unknown'}/experiment-viewer-${job.id}`}
-                  sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}
-                >
-                  H5 viewer
-                </Button>
-              )}
               <Button
                 variant="contained"
                 startIcon={downloadingSingle === output ? null : <Download />}
@@ -730,6 +716,22 @@ const Row: React.FC<{
                     >
                       <Button variant="contained" sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}>
                         Value editor
+                      </Button>
+                    </Link>
+                    <Link
+                      to={`/experiment-viewer?instrument=${job.run.instrument_name}&experiment=${job.run.experiment_number}`}
+                      onClick={() =>
+                        ReactGA.event({
+                          category: 'Button',
+                          action: 'Click',
+                          label: 'Experiment viewer button',
+                          value: job.id,
+                        })
+                      }
+                      style={{ textDecoration: 'none' }}
+                    >
+                      <Button variant="contained" sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}>
+                        Experiment viewer
                       </Button>
                     </Link>
                     <Button

--- a/src/lib/useLiveDataSSE.ts
+++ b/src/lib/useLiveDataSSE.ts
@@ -64,7 +64,6 @@ export function useLiveDataSSE(instrument: string | null, enabled: boolean = tru
 
       eventSource.addEventListener('connected', (event) => {
         const data = JSON.parse(event.data);
-        console.log('[LiveDataSSE] Connected to directory:', data.directory);
         setDirectory(data.directory);
         setIsConnected(true);
         setError(null);
@@ -72,7 +71,6 @@ export function useLiveDataSSE(instrument: string | null, enabled: boolean = tru
 
       eventSource.addEventListener('file_changed', (event) => {
         const data: FileChangedEvent = JSON.parse(event.data);
-        console.log('[LiveDataSSE] File changed:', data);
         setChangedFile(data);
         setLastUpdated(new Date());
       });
@@ -92,13 +90,8 @@ export function useLiveDataSSE(instrument: string | null, enabled: boolean = tru
 
         // Attempt to reconnect after 5 seconds
         reconnectTimeoutRef.current = setTimeout(() => {
-          console.log('[LiveDataSSE] Reconnecting...');
           connect();
         }, 5000);
-      };
-
-      eventSource.onopen = () => {
-        console.log('[LiveDataSSE] Connection opened');
       };
     };
 

--- a/src/pages/ExperimentViewer.tsx
+++ b/src/pages/ExperimentViewer.tsx
@@ -44,6 +44,7 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
     const exp = searchParams.get('experiment');
     return exp ? parseInt(exp, 10) : null;
   });
+  const [searchLimit, setSearchLimit] = useState<number>(10);
   const [isSearchActive, setIsSearchActive] = useState<boolean>(() => {
     return Boolean(searchParams.get('instrument') || searchParams.get('experiment'));
   });
@@ -90,7 +91,7 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
             params: {
               filters: JSON.stringify(filters),
               include_run: 'true',
-              limit: 100,
+              limit: searchLimit,
             },
           });
           jobsData = response.data;
@@ -211,12 +212,13 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
     };
 
     loadJobs();
-  }, [jobId, instrumentName, isSearchActive, searchInstrument, searchExperimentNumber]);
+  }, [jobId, instrumentName, isSearchActive, searchInstrument, searchExperimentNumber, searchLimit]);
 
   // Search handlers
-  const handleSearch = (instrument: string | null, experimentNumber: number | null): void => {
+  const handleSearch = (instrument: string | null, experimentNumber: number | null, limit: number): void => {
     setSearchInstrument(instrument);
     setSearchExperimentNumber(experimentNumber);
+    setSearchLimit(limit);
     setIsSearchActive(true);
     setError(null);
 

--- a/src/pages/ExperimentViewer.tsx
+++ b/src/pages/ExperimentViewer.tsx
@@ -101,8 +101,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
           return;
         }
 
-        console.log('Fetched jobs:', jobsData);
-
         // Create file configs for all output files and fetch their full paths
         const allFiles: FileConfig[] = [];
 
@@ -112,7 +110,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
 
         // Filter jobs to only include H5 files in outputs and store filtered outputs back
         const filteredJobs = jobsData.map((job) => {
-          console.log('Job outputs:', job.outputs);
 
           // Parse outputs - handle 3 cases:
           // 1. Lists like "['file1', 'file2']" - split on "', '"
@@ -135,8 +132,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
             outputs = [outputStr];
           }
 
-          console.log('Parsed outputs:', outputs);
-
           // Filter to only keep valid H5 files (handles case 3 - filters garbage)
           const h5Outputs = outputs.filter((output) => {
             // Must be a string with valid file extension
@@ -144,8 +139,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
               typeof output === 'string' && output.length > 0 && outputFilter.some((filter) => output.endsWith(filter))
             );
           });
-
-          console.log('Filtered job outputs:', h5Outputs);
 
           // Collect unique filenames
           h5Outputs.forEach((output) => {
@@ -158,8 +151,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
             }
           });
 
-          console.log('All filenames:', allFilenames);
-
           // Return job with filtered outputs as comma-separated string for FileTree
           return {
             ...job,
@@ -167,7 +158,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
           };
         });
 
-        console.log('Filtered jobs with H5 outputs:', filteredJobs);
         setJobs(filteredJobs);
 
         // Fetch full paths for all files in parallel
@@ -201,7 +191,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
           });
         });
 
-        console.log('Files with paths:', allFiles);
         setFiles(allFiles);
       } catch (err) {
         console.error('Error loading jobs:', err);
@@ -255,9 +244,7 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
       }
 
       try {
-        console.log(`[H5Grove] Discovering datasets in ${file.filename}...`);
         const structure = await discoverFileStructure(file.filename, file.fullPath);
-        console.log('[H5Grove] API response:', structure);
 
         // Convert discovered datasets to our format
         const discoveredDatasets: DatasetInfo[] = structure.datasets.map((ds) => ({
@@ -269,8 +256,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
           is2D: ds.is2D,
           isPrimary: ds.isPrimary,
         }));
-
-        console.log('[H5Grove] Discovered datasets:', discoveredDatasets);
 
         // Update file config with discovered datasets
         setFiles((prevFiles) =>
@@ -297,10 +282,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
                   selection: [],
                 };
 
-                console.log(
-                  `[H5Grove] Auto-selected ${primaryDataset ? 'primary' : 'first'} dataset:`,
-                  datasetToSelect.path
-                );
               }
 
               return updatedFile;
@@ -308,8 +289,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
             return f;
           })
         );
-
-        console.log(`[H5Grove] Discovered ${discoveredDatasets.length} datasets in ${file.filename}`);
       } catch (error) {
         console.error(`[H5Grove] Failed to discover datasets in ${file.filename}:`, error);
         // Mark as discovered anyway to avoid repeated attempts
@@ -386,7 +365,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
           if (is1DDataset) {
             return [
               (async () => {
-                console.log('Fetching 1D data for:', fileToFetch, '- path:', file.path);
                 const data = await fetchData1D(fileToFetch, file.path!, undefined);
 
                 let errors: number[] | undefined;
@@ -412,8 +390,6 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
 
           return selections.map((slice) =>
             (async () => {
-              console.log('Fetching slice', slice, 'for:', fileToFetch, '- path:', file.path);
-
               const data = await fetchData1D(fileToFetch, file.path!, slice);
 
               let errors: number[] | undefined;

--- a/src/pages/LiveData.tsx
+++ b/src/pages/LiveData.tsx
@@ -120,7 +120,6 @@ const LiveData: React.FC = (): JSX.Element => {
 
     // Refresh viewer if the currently selected file was modified
     if (changedFile.file === selectedFile && changedFile.change_type === 'modified') {
-      console.log('[LiveData] Selected file modified, refreshing viewer');
       setViewerKey((prev) => prev + 1);
     }
   }, [changedFile, selectedFile, loadFiles]);


### PR DESCRIPTION
Small refactor of the fronted to remove debug log statements, simplify component tree and make the code more maintainable by reducing its size and complexity.

This PR also has a few optimisation features like limiting the amount of outputs displayed and a minor UX change to move the experiment viewer button to the run level instead of the output level.

There is also a fix for the auxiliary lines domain, so shorter auxiliary lines are padded with NaNs so they can render 