### PR TITLE
Add Cypress E2E tests and CI workflow

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -6,6 +6,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+      - name: Ensure Submodules
+        run: git submodule update --init --recursive
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           install: false
           component: true
+          spec: cypress/component/**/*.cy.{js,jsx,ts,tsx}
       - name: Run Cypress E2E Tests
         uses: cypress-io/github-action@v7
         env:
@@ -33,3 +34,4 @@ jobs:
           start: yarn start --host 127.0.0.1 --port 3000 --strictPort
           wait-on: 'http://127.0.0.1:3000'
           wait-on-timeout: 300
+          spec: cypress/e2e/**/*.cy.{js,jsx,ts,tsx}

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -18,8 +18,8 @@ jobs:
         env:
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
         with:
-          start: yarn start
-          wait-on: 'http://localhost:3000'
+          start: yarn start --host 127.0.0.1
+          wait-on: 'http://127.0.0.1:3000'
           wait-on-timeout: 300
           component: true
       - name: Run Cypress E2E Tests
@@ -28,6 +28,6 @@ jobs:
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
         with:
           install: false
-          start: yarn start
-          wait-on: 'http://localhost:3000'
+          start: yarn start --host 127.0.0.1
+          wait-on: 'http://127.0.0.1:3000'
           wait-on-timeout: 300

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -18,9 +18,7 @@ jobs:
         env:
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
         with:
-          start: yarn start --host 127.0.0.1
-          wait-on: 'http://127.0.0.1:3000'
-          wait-on-timeout: 300
+          install: false
           component: true
       - name: Run Cypress E2E Tests
         uses: cypress-io/github-action@v7
@@ -28,6 +26,6 @@ jobs:
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
         with:
           install: false
-          start: yarn start --host 127.0.0.1
+          start: yarn start --host 127.0.0.1 --port 3000 --strictPort
           wait-on: 'http://127.0.0.1:3000'
           wait-on-timeout: 300

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -13,7 +13,7 @@ jobs:
           cache: 'yarn'
       - name: Install Dependencies
         run: yarn install
-      - name: Run Cypress Tests
+      - name: Run Cypress Component Tests
         uses: cypress-io/github-action@v7
         env:
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
@@ -22,3 +22,12 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 300
           component: true
+      - name: Run Cypress E2E Tests
+        uses: cypress-io/github-action@v7
+        env:
+          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+        with:
+          install: false
+          start: yarn start
+          wait-on: 'http://localhost:3000'
+          wait-on-timeout: 300

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ rm -rf node_modules && yarn cache clean && rm -f yarn.lock && yarn install
 
 The FIA frontend uses [Cypress](https://www.cypress.io/) for end-to-end and component testing. These tests run in a [workflow](.github/workflows/cypress_tests.yml) whenever a commit is pushed or a pull request is merged. Tests can also be run locally.
 
-For writing your own tests, follow the guide [here](https://docs.cypress.io/guides/end-to-end-testing/writing-your-first-end-to-end-test). Alternatively, replicate the methods used in pre-existing `.cy.tsx` files, like the [homepage](cypress/component/Homepage.cy.tsx).
+For writing your own tests, follow the guide [here](https://docs.cypress.io/guides/end-to-end-testing/writing-your-first-end-to-end-test). Component examples live in [`cypress/component`](cypress/component), and e2e examples live in [`cypress/e2e`](cypress/e2e).
+
+The e2e tests are written to work in plugin-style routing (`/fia/...`) and stub API responses with `cy.intercept(...)` so they do not require live SciGateway-backed authentication data.
 
 ## Additional scripts
 
@@ -154,7 +156,15 @@ Opens the Cypress Test Runner. This provides a graphical display for running end
 
 ### `yarn cypress run`
 
-Runs Cypress tests headlessly in the terminal. This is useful for running tests in a CI/CD pipeline (currently there are no e2e spec files so shouldn't do anything).
+Runs Cypress tests headlessly in the terminal.
+
+### `yarn cypress:run:e2e`
+
+Runs only end-to-end specs.
+
+### `yarn cypress:run:component`
+
+Runs only component specs.
 
 ### `yarn run-frontend`
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   },
 
   e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: 'cypress/support/e2e.ts',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   component: {
+    specPattern: 'cypress/component/**/*.cy.{js,jsx,ts,tsx}',
     devServer: {
       framework: 'create-react-app',
       bundler: 'webpack',
@@ -11,6 +12,7 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://127.0.0.1:3000',
     supportFile: 'cypress/support/e2e.ts',
+    specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
 
   e2e: {
-    baseUrl: 'http://localhost:3000',
+    baseUrl: 'http://127.0.0.1:3000',
     supportFile: 'cypress/support/e2e.ts',
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -1,0 +1,17 @@
+describe('FIA plugin navigation', () => {
+  it('redirects unknown routes back to the homepage', () => {
+    cy.visitFia('/fia/not-a-real-route');
+
+    cy.location('pathname').should('match', /\/fia\/?$/);
+    cy.contains('Data reduction').should('be.visible');
+  });
+
+  it('navigates from homepage to instruments', () => {
+    cy.visitFia('/fia');
+
+    cy.get('a[href="/fia/instruments"]').first().click();
+
+    cy.location('pathname').should('eq', '/fia/instruments');
+    cy.contains('h1', 'ISIS instruments').should('be.visible');
+  });
+});

--- a/cypress/e2e/reduction-history.cy.ts
+++ b/cypress/e2e/reduction-history.cy.ts
@@ -1,0 +1,115 @@
+const baseJob = {
+  start: '2025-01-01T10:00:00Z',
+  end: '2025-01-01T10:15:00Z',
+  state: 'SUCCESSFUL',
+  status_message: '',
+  runner_image: 'ghcr.io/fiaisis/runner@sha256:abc123',
+  type: 'JobType.REDUCTION',
+  inputs: {
+    detector_mode: 'high',
+  },
+  outputs: "['LOQ00012345.nxs']",
+  stacktrace: '',
+  script: {
+    value: 'print("rerun")',
+  },
+};
+
+const allJobsResponse = [
+  {
+    ...baseJob,
+    id: 101,
+    run: {
+      experiment_number: 12345,
+      filename: '/archive/LOQ00012345.nxs',
+      run_start: '2025-01-01T09:00:00Z',
+      run_end: '2025-01-01T09:30:00Z',
+      title: 'All instruments reduction',
+      users: 'Dr. Doe',
+      good_frames: 125000,
+      raw_frames: 130000,
+      instrument_name: 'LOQ',
+    },
+  },
+];
+
+const loqJobsResponse = [
+  {
+    ...baseJob,
+    id: 202,
+    run: {
+      experiment_number: 67890,
+      filename: '/archive/LOQ00067890.nxs',
+      run_start: '2025-01-02T09:00:00Z',
+      run_end: '2025-01-02T09:30:00Z',
+      title: 'LOQ scoped reduction',
+      users: 'Dr. Smith',
+      good_frames: 98000,
+      raw_frames: 101000,
+      instrument_name: 'LOQ',
+    },
+  },
+];
+
+describe('Reduction history page', () => {
+  it('loads with mocked auth-aware API responses and supports instrument scoping', () => {
+    cy.intercept('GET', /\/api\/jobs\/runners$/, (req) => {
+      expect(req.headers.authorization).to.match(/^Bearer(?: .+)?$/);
+      req.reply({
+        statusCode: 200,
+        body: { 'sha256:abc123': 'Mantid 6.9.0' },
+      });
+    }).as('getRunners');
+
+    cy.intercept('GET', /\/api\/jobs\/count\?.*$/, (req) => {
+      expect(req.headers.authorization).to.match(/^Bearer(?: .+)?$/);
+      req.reply({
+        statusCode: 200,
+        body: { count: allJobsResponse.length },
+      });
+    }).as('getAllCount');
+
+    cy.intercept('GET', /\/api\/jobs\?.*$/, (req) => {
+      expect(req.headers.authorization).to.match(/^Bearer(?: .+)?$/);
+      req.reply({
+        statusCode: 200,
+        body: allJobsResponse,
+      });
+    }).as('getAllJobs');
+
+    cy.intercept('GET', /\/api\/instrument\/LOQ\/jobs\/count\?.*$/, (req) => {
+      expect(req.headers.authorization).to.match(/^Bearer(?: .+)?$/);
+      req.reply({
+        statusCode: 200,
+        body: { count: loqJobsResponse.length },
+      });
+    }).as('getLoqCount');
+
+    cy.intercept('GET', /\/api\/instrument\/LOQ\/jobs\?.*$/, (req) => {
+      expect(req.headers.authorization).to.match(/^Bearer(?: .+)?$/);
+      req.reply({
+        statusCode: 200,
+        body: loqJobsResponse,
+      });
+    }).as('getLoqJobs');
+
+    cy.visitFia('/fia/reduction-history');
+
+    cy.wait('@getRunners');
+    cy.wait('@getAllCount');
+    cy.wait('@getAllJobs');
+
+    cy.contains('h1', 'ALL reductions').should('be.visible');
+    cy.contains('All instruments reduction').should('be.visible');
+
+    cy.get('[role="combobox"][aria-labelledby="instrument-select-label"]').click();
+    cy.get('li[role="option"][data-value="LOQ"]').click();
+
+    cy.wait('@getLoqCount');
+    cy.wait('@getLoqJobs');
+
+    cy.location('pathname').should('eq', '/fia/reduction-history/LOQ');
+    cy.contains('h1', 'LOQ reductions').should('be.visible');
+    cy.contains('LOQ scoped reduction').should('be.visible');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "prettier --config .prettierrc --write",
       "git add"
     ],
-    "cypress/**/*.{tsx,js,jsx}": [
+    "cypress/**/*.{ts,tsx,js,jsx}": [
       "eslint --fix",
       "prettier --config .prettierrc --write",
       "git add"
@@ -83,6 +83,10 @@
     "eject": "react-scripts eject",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
+    "cypress:open:e2e": "cypress open --e2e",
+    "cypress:run:e2e": "cypress run --e2e",
+    "cypress:open:component": "cypress open --component",
+    "cypress:run:component": "cypress run --component",
     "run-frontend": "yarn build && cd ../scigateway && yarn dev",
     "format": "prettier --write .",
     "format:check": "prettier --check ."


### PR DESCRIPTION
Closes #652.

## Description

Add initial Cypress end-to-end coverage for the frontend app, plus CI wiring so these tests run on GitHub Actions.

## Why
We had Cypress component tests but no frontend e2e specs for key user flows. This adds a baseline e2e suite that is stable in local/CI by mocking auth-dependent API calls.

## Changes
- Added e2e specs:
  - `cypress/e2e/navigation.cy.ts`
    - unknown route redirects back to `/fia`
    - homepage -> instruments navigation
  - `cypress/e2e/reduction-history.cy.ts`
    - reduction history loads with mocked API responses
    - instrument scoping (`ALL` -> `LOQ`) updates route and table content
- Added Cypress custom command in `cypress/support/commands.ts`:
  - `cy.visitFia(path?)` to set plugin-style localStorage auth state and visit `/fia...` routes
- Updated `cypress.config.ts`:
  - set `e2e.baseUrl` to `http://localhost:3000`
  - set `e2e.supportFile` to `cypress/support/e2e.ts`
- Updated `package.json` scripts:
  - `cypress:run:e2e`
  - `cypress:run:component`
  - `cypress:open:e2e`
  - `cypress:open:component`
- Updated lint-staged in `package.json` to include Cypress `.ts` files.
- Updated CI workflow `.github/workflows/cypress_tests.yml`:
  - keep component test job
  - add separate Cypress e2e run
- Updated docs in `README.md`:
  - where component vs e2e specs live
  - how to run e2e/component separately
  - note that e2e tests use mocked API responses

## Validation
- Lint passed for new/updated Cypress TS files.
- New e2e specs pass locally (headless):
  - `cypress/e2e/navigation.cy.ts`
  - `cypress/e2e/reduction-history.cy.ts`

## Notes
- These are frontend-level e2e tests against the standalone dev server, not full SciGateway plugin-host integration tests.
- No production/runtime frontend feature logic was changed.

