### PR TITLE
Add 1D plot customization controls for experiment-viewer

### DIFF
--- a/src/components/experimentViewer/FileCard.tsx
+++ b/src/components/experimentViewer/FileCard.tsx
@@ -149,7 +149,7 @@ const FileCard: React.FC<FileCardProps> = ({
                             />
                           )}
                           <Chip
-                            label={dataset.shape.join(' × ')}
+                            label={dataset.shape.join(' x ')}
                             size="small"
                             sx={{ height: 18, fontSize: '0.65rem' }}
                           />
@@ -196,7 +196,7 @@ const FileCard: React.FC<FileCardProps> = ({
                 {/* Mode toggle */}
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                   <Typography variant="body2" fontWeight="500">
-                    Slice Selection (2D → 1D)
+                    Slice selection (2D → 1D)
                   </Typography>
                   <ToggleButtonGroup
                     size="small"

--- a/src/components/experimentViewer/FileTree.tsx
+++ b/src/components/experimentViewer/FileTree.tsx
@@ -21,6 +21,7 @@ interface FileTreeProps {
   onFileToggle: (index: number) => void;
   onDatasetChange: (index: number, datasetPath: string) => void;
   onSelectionChange: (index: number, selections: number[]) => void;
+  initialExpandedJobIds?: number[];
   autoSelectPrimary?: boolean;
   onAutoSelectPrimaryChange?: (enabled: boolean) => void;
   activeViewerTab?: '1d' | '2d';
@@ -34,13 +35,14 @@ const FileTree: React.FC<FileTreeProps> = ({
   onFileToggle,
   onDatasetChange,
   onSelectionChange,
+  initialExpandedJobIds = [],
   autoSelectPrimary = false,
   onAutoSelectPrimaryChange,
   activeViewerTab = '1d',
   selected2DFile = null,
   onSelect2DFile,
 }): JSX.Element => {
-  const [expandedJobs, setExpandedJobs] = useState<Set<number>>(new Set());
+  const [expandedJobs, setExpandedJobs] = useState<Set<number>>(() => new Set(initialExpandedJobIds));
   const [showEmptyJobs, setShowEmptyJobs] = useState(false);
   const [inputMode, setInputMode] = useState<'text' | 'chips'>('text');
 
@@ -100,7 +102,7 @@ const FileTree: React.FC<FileTreeProps> = ({
     >
       <Box sx={{ mb: 2 }}>
         <Typography variant="h5" fontWeight="bold" sx={{ mb: 1 }}>
-          File Tree
+          File tree
         </Typography>
 
         {/* Settings */}

--- a/src/components/experimentViewer/Graph.tsx
+++ b/src/components/experimentViewer/Graph.tsx
@@ -43,6 +43,7 @@ const CURVE_TYPE_LABELS: Record<CurveType, string> = {
 const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onShowErrorsChange }): JSX.Element => {
   const theme = useTheme();
 
+  // State for line plot controls
   const [showGrid, setShowGrid] = useState(true);
   const [xScaleType, setXScaleType] = useState<AxisScaleType>(ScaleType.Linear);
   const [yScaleType, setYScaleType] = useState<AxisScaleType>(ScaleType.Linear);
@@ -50,6 +51,7 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
   const [interpolation, setInterpolation] = useState(Interpolation.Linear);
   const [customDomain, setCustomDomain] = useState<CustomDomain>([null, null]);
 
+  // Handle the empty state before building plot arrays
   if (linePlotData.length === 0) {
     return (
       <Box
@@ -73,23 +75,30 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
     );
   }
 
-  // Keep the longest line as primary so auxiliary arrays can be padded safely.
+  // Keep the longest series as primary so shorter auxiliary arrays can be padded safely
+  // This avoids h5web edge cases where an auxiliary line is longer than the primary one
   const sortedData = [...linePlotData].sort((a, b) => b.data.length - a.data.length);
+  // Render the longest series as primary and pass the rest to LineVis as auxiliaries
   const primaryData = sortedData[0];
   const primaryLength = primaryData.data.length;
 
   const primaryArray = ndarray(primaryData.data, [primaryLength]);
+  // Generate index-based x-values for the primary series
   const primaryAbscissas = Float32Array.from({ length: primaryLength }, (_, index) => index);
+  // Include error bars only when the dataset provides them and the toggle is enabled
   const primaryErrorsArray =
     showErrors && primaryData.errors ? ndarray(primaryData.errors, [primaryData.errors.length]) : undefined;
 
+  // Pad auxiliary series with NaN so shorter lines align with the primary length without rendering extra points
   const auxiliaries = sortedData.slice(1).map((data) => {
+    // h5web skips NaN samples, so padding preserves alignment without drawing fake values
     const paddedData = new Float32Array(primaryLength);
     paddedData.set(data.data);
     if (data.data.length < primaryLength) {
       paddedData.fill(NaN, data.data.length);
     }
 
+    // Error arrays need the same padding so error bars stay aligned with their data points
     let paddedErrors: Float32Array | undefined;
     if (showErrors && data.errors) {
       paddedErrors = new Float32Array(primaryLength);
@@ -106,24 +115,28 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
     };
   });
 
+  // Combine the visible Y-domain across the primary series and every auxiliary series
   const combinedDomain =
     getCombinedDomain([
       getDomain(primaryArray, yScaleType, primaryErrorsArray),
       ...auxiliaries.map((auxiliary) => getDomain(auxiliary.array, yScaleType, auxiliary.errors)),
     ]) || DEFAULT_DOMAIN;
 
+  // Merge any user-entered domain overrides, then clamp them to something safe for the active scale
   const visDomain = getVisDomain(customDomain, combinedDomain);
   const [safeDomain] = getSafeDomain(visDomain, combinedDomain, yScaleType);
   const hasErrorSupport = linePlotData.some((plot) => plot.supportsErrors);
   const toolbarBackground = theme.palette.background.paper;
   const popupBackground =
     theme.palette.mode === 'dark' ? theme.palette.background.default : theme.palette.background.paper;
+  const primaryCurveColor = theme.palette.mode === 'dark' ? theme.palette.info.light : theme.palette.primary.dark;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
       <Paper
         elevation={1}
         sx={{
+          // Keep h5web toolbar and popup controls aligned with the surrounding MUI theme
           color: theme.palette.text.primary,
           borderBottom: 1,
           borderColor: 'divider',
@@ -153,6 +166,7 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
       >
         <Box sx={{ display: 'flex' }} className="toolbar">
           <Toolbar>
+            {/* Y-domain controls */}
             <DomainWidget
               dataDomain={combinedDomain}
               customDomain={customDomain}
@@ -160,6 +174,7 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
               onCustomDomainChange={setCustomDomain}
             />
             <Separator />
+            {/* Axis scale controls */}
             <ScaleSelector value={xScaleType} onScaleChange={setXScaleType} options={AXIS_SCALE_TYPES} label="X" />
             <ScaleSelector value={yScaleType} onScaleChange={setYScaleType} options={AXIS_SCALE_TYPES} label="Y" />
             <Separator />
@@ -167,6 +182,7 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
               <ToggleBtn label="Error bars" value={showErrors} onToggle={() => onShowErrorsChange(!showErrors)} />
             )}
             <ToggleBtn label="Grid" value={showGrid} onToggle={() => setShowGrid(!showGrid)} />
+            {/* Curve and interpolation controls */}
             <Menu label="Style">
               <RadioGroup
                 name="curve-type"
@@ -189,19 +205,21 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
         </Box>
       </Paper>
 
-      <LineVis
-        dataArray={primaryArray}
-        domain={safeDomain}
-        errorsArray={primaryErrorsArray}
-        showErrors={showErrors}
-        auxiliaries={auxiliaries.length > 0 ? auxiliaries : undefined}
-        showGrid={showGrid}
-        scaleType={yScaleType}
-        curveType={curveType}
-        interpolation={interpolation}
-        ordinateLabel="Value"
-        abscissaParams={{ label: 'Index', scaleType: xScaleType, value: primaryAbscissas }}
-      />
+      <Box sx={{ flex: 1, minHeight: 0, '--h5w-line--color': primaryCurveColor }}>
+        <LineVis
+          dataArray={primaryArray}
+          domain={safeDomain}
+          errorsArray={primaryErrorsArray}
+          showErrors={showErrors}
+          auxiliaries={auxiliaries.length > 0 ? auxiliaries : undefined}
+          showGrid={showGrid}
+          scaleType={yScaleType}
+          curveType={curveType}
+          interpolation={interpolation}
+          ordinateLabel="Value"
+          abscissaParams={{ label: 'Index', scaleType: xScaleType, value: primaryAbscissas }}
+        />
+      </Box>
     </Box>
   );
 };

--- a/src/components/experimentViewer/Graph.tsx
+++ b/src/components/experimentViewer/Graph.tsx
@@ -115,15 +115,40 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
   const visDomain = getVisDomain(customDomain, combinedDomain);
   const [safeDomain] = getSafeDomain(visDomain, combinedDomain, yScaleType);
   const hasErrorSupport = linePlotData.some((plot) => plot.supportsErrors);
+  const toolbarBackground = theme.palette.background.paper;
+  const popupBackground =
+    theme.palette.mode === 'dark' ? theme.palette.background.default : theme.palette.background.paper;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
       <Paper
         elevation={1}
         sx={{
-          '--h5w-btn-hover--bgColor': theme.palette.background.default,
-          '--h5w-toolbar--bgColor': theme.palette.background.paper,
+          color: theme.palette.text.primary,
+          borderBottom: 1,
+          borderColor: 'divider',
+          '--h5w-btn-hover--bgColor': theme.palette.action.hover,
+          '--h5w-toolbar--bgColor': toolbarBackground,
+          '--h5w-toolbar-popup--bgColor': popupBackground,
           '--h5w-btnPressed--bgColor': theme.palette.primary.main,
+          '--h5w-toolbar-label--color': theme.palette.text.primary,
+          '--h5w-toolbar-separator--color': theme.palette.divider,
+          '--h5w-selector-label--color': theme.palette.text.primary,
+          '--h5w-selector-arrowIcon--color': theme.palette.text.secondary,
+          '--h5w-selector-groupLabel--color': theme.palette.text.secondary,
+          '--h5w-selector-menu--bgColor': popupBackground,
+          '--h5w-selector-option-hover--bgColor': theme.palette.action.hover,
+          '--h5w-selector-option-selected--bgColor': theme.palette.action.selected,
+          '--h5w-selector-option-focus--outlineColor': theme.palette.primary.main,
+          '--h5w-domainWidget-popup--bgColor': popupBackground,
+          '--h5w-domainControls--colorAlt': theme.palette.text.primary,
+          '--h5w-domainControls-boundInput--shadowColor': theme.palette.divider,
+          '--h5w-domainControls-boundInput-focus--shadowColor': theme.palette.primary.main,
+          '--h5w-domainControls-boundInput-editing--bgColor': theme.palette.background.paper,
+          '--h5w-domainControls-boundInput-editing--borderColor': theme.palette.primary.main,
+          '--h5w-toolbar-input--shadowColor': theme.palette.divider,
+          '--h5w-toolbar-input-hover--shadowColor': theme.palette.text.secondary,
+          '--h5w-toolbar-input-focus--shadowColor': theme.palette.primary.main,
         }}
       >
         <Box sx={{ display: 'flex' }} className="toolbar">

--- a/src/components/experimentViewer/Graph.tsx
+++ b/src/components/experimentViewer/Graph.tsx
@@ -164,7 +164,7 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
             <ScaleSelector value={yScaleType} onScaleChange={setYScaleType} options={AXIS_SCALE_TYPES} label="Y" />
             <Separator />
             {hasErrorSupport && (
-              <ToggleBtn label="Error Bars" value={showErrors} onToggle={() => onShowErrorsChange(!showErrors)} />
+              <ToggleBtn label="Error bars" value={showErrors} onToggle={() => onShowErrorsChange(!showErrors)} />
             )}
             <ToggleBtn label="Grid" value={showGrid} onToggle={() => setShowGrid(!showGrid)} />
             <Menu label="Style">

--- a/src/components/experimentViewer/Graph.tsx
+++ b/src/components/experimentViewer/Graph.tsx
@@ -1,8 +1,28 @@
 import React, { useState } from 'react';
 import ndarray from 'ndarray';
-import { getDomain, LineVis, ScaleType, ScaleSelector, Separator, ToggleBtn, Toolbar } from '@h5web/lib';
-import type { LinePlotData } from '../../lib/types';
+import {
+  AXIS_SCALE_TYPES,
+  CurveType,
+  DomainWidget,
+  getCombinedDomain,
+  getDomain,
+  getSafeDomain,
+  getVisDomain,
+  Interpolation,
+  LineVis,
+  Menu,
+  RadioGroup,
+  ScaleSelector,
+  Separator,
+  type AxisScaleType,
+  type CustomDomain,
+  type Domain,
+  ScaleType,
+  ToggleBtn,
+  Toolbar,
+} from '@h5web/lib';
 import { Box, Paper, Typography, useTheme } from '@mui/material';
+import type { LinePlotData } from '../../lib/types';
 
 interface PlotViewerProps {
   linePlotData: LinePlotData[];
@@ -10,15 +30,26 @@ interface PlotViewerProps {
   onShowErrorsChange: (showErrors: boolean) => void;
 }
 
+const DEFAULT_DOMAIN: Domain = [0.1, 1];
+const CURVE_TYPE_OPTIONS = Object.values(CurveType) as CurveType[];
+const INTERPOLATION_OPTIONS = Object.values(Interpolation) as Interpolation[];
+
+const CURVE_TYPE_LABELS: Record<CurveType, string> = {
+  [CurveType.LineOnly]: 'Lines',
+  [CurveType.GlyphsOnly]: 'Points',
+  [CurveType.LineAndGlyphs]: 'Both',
+};
+
 const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onShowErrorsChange }): JSX.Element => {
   const theme = useTheme();
 
-  // State for line plot controls
-  const [lineShowGrid, setLineShowGrid] = useState(true);
-  const [xScaleType, setXScaleType] = useState<ScaleType.Linear | ScaleType.Log | ScaleType.SymLog>(ScaleType.Linear);
-  const [yScaleType, setYScaleType] = useState<ScaleType.Linear | ScaleType.Log | ScaleType.SymLog>(ScaleType.Linear);
+  const [showGrid, setShowGrid] = useState(true);
+  const [xScaleType, setXScaleType] = useState<AxisScaleType>(ScaleType.Linear);
+  const [yScaleType, setYScaleType] = useState<AxisScaleType>(ScaleType.Linear);
+  const [curveType, setCurveType] = useState(CurveType.LineOnly);
+  const [interpolation, setInterpolation] = useState(Interpolation.Linear);
+  const [customDomain, setCustomDomain] = useState<CustomDomain>([null, null]);
 
-  // Handle empty state
   if (linePlotData.length === 0) {
     return (
       <Box
@@ -42,34 +73,23 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
     );
   }
 
-  // Sort data by domain size (largest first) to ensure the file with the biggest domain is primary
-  // This prevents crashes when auxiliary data has a larger domain than primary
+  // Keep the longest line as primary so auxiliary arrays can be padded safely.
   const sortedData = [...linePlotData].sort((a, b) => b.data.length - a.data.length);
-
-  // Render line plots - largest domain as primary, rest as auxiliaries
   const primaryData = sortedData[0];
+  const primaryLength = primaryData.data.length;
 
-  const primaryArray = ndarray(primaryData.data, [primaryData.data.length]);
-
-  // Generate abscissas (x-values) for primary data based on its length
-  const primaryAbscissas = Float32Array.from({ length: primaryData.data.length }, (_, i) => i);
-
-  // Create error array if available and showErrors is true
+  const primaryArray = ndarray(primaryData.data, [primaryLength]);
+  const primaryAbscissas = Float32Array.from({ length: primaryLength }, (_, index) => index);
   const primaryErrorsArray =
     showErrors && primaryData.errors ? ndarray(primaryData.errors, [primaryData.errors.length]) : undefined;
 
-  // Create auxiliaries for additional lines with error bars
-  // Pad auxiliary arrays with NaN to match primary length (NaN values won't render)
-  const primaryLength = primaryData.data.length;
   const auxiliaries = sortedData.slice(1).map((data) => {
-    // Pad data array with NaN if shorter than primary
     const paddedData = new Float32Array(primaryLength);
     paddedData.set(data.data);
     if (data.data.length < primaryLength) {
       paddedData.fill(NaN, data.data.length);
     }
 
-    // Pad errors array with NaN if available and shorter than primary
     let paddedErrors: Float32Array | undefined;
     if (showErrors && data.errors) {
       paddedErrors = new Float32Array(primaryLength);
@@ -82,69 +102,80 @@ const PlotViewer: React.FC<PlotViewerProps> = ({ linePlotData, showErrors, onSho
     return {
       array: ndarray(paddedData, [primaryLength]),
       label: data.filename,
-      color: data.color,
       errors: paddedErrors ? ndarray(paddedErrors, [primaryLength]) : undefined,
     };
   });
 
-  // Calculate combined Y domain across all data to ensure proper graph sizing
-  // Start with primary data domain
-  let combinedDomain = getDomain(primaryArray, yScaleType, primaryErrorsArray);
+  const combinedDomain =
+    getCombinedDomain([
+      getDomain(primaryArray, yScaleType, primaryErrorsArray),
+      ...auxiliaries.map((auxiliary) => getDomain(auxiliary.array, yScaleType, auxiliary.errors)),
+    ]) || DEFAULT_DOMAIN;
 
-  // Extend domain to include all auxiliaries
-  for (const aux of auxiliaries) {
-    const auxDomain = getDomain(aux.array, yScaleType, aux.errors);
-    if (auxDomain && combinedDomain) {
-      combinedDomain = [Math.min(combinedDomain[0], auxDomain[0]), Math.max(combinedDomain[1], auxDomain[1])];
-    }
-  }
-
-  const domain = combinedDomain;
+  const visDomain = getVisDomain(customDomain, combinedDomain);
+  const [safeDomain] = getSafeDomain(visDomain, combinedDomain, yScaleType);
+  const hasErrorSupport = linePlotData.some((plot) => plot.supportsErrors);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
       <Paper
         elevation={1}
         sx={{
-          // For more customization please see https://h5web-docs.panosc.eu/?path=/docs/customization--docs
           '--h5w-btn-hover--bgColor': theme.palette.background.default,
           '--h5w-toolbar--bgColor': theme.palette.background.paper,
           '--h5w-btnPressed--bgColor': theme.palette.primary.main,
         }}
       >
-        <Box sx={{ display: 'flex' }} className={'toolbar'}>
+        <Box sx={{ display: 'flex' }} className="toolbar">
           <Toolbar>
-            {/* Y-axis scale selector */}
-            <ScaleSelector
-              value={yScaleType}
-              onScaleChange={setYScaleType}
-              options={[ScaleType.Linear, ScaleType.Log, ScaleType.SymLog]}
-              label="Y scale"
+            <DomainWidget
+              dataDomain={combinedDomain}
+              customDomain={customDomain}
+              scaleType={yScaleType}
+              onCustomDomainChange={setCustomDomain}
             />
             <Separator />
-            {/* X-axis scale selector */}
-            <ScaleSelector
-              value={xScaleType}
-              onScaleChange={setXScaleType}
-              options={[ScaleType.Linear, ScaleType.Log, ScaleType.SymLog]}
-              label="X scale"
-            />
+            <ScaleSelector value={xScaleType} onScaleChange={setXScaleType} options={AXIS_SCALE_TYPES} label="X" />
+            <ScaleSelector value={yScaleType} onScaleChange={setYScaleType} options={AXIS_SCALE_TYPES} label="Y" />
             <Separator />
-            <ToggleBtn label="Grid" value={lineShowGrid} onToggle={() => setLineShowGrid(!lineShowGrid)} />
-            <Separator />
-            <ToggleBtn label="Error Bars" value={showErrors} onToggle={() => onShowErrorsChange(!showErrors)} />
+            {hasErrorSupport && (
+              <ToggleBtn label="Error Bars" value={showErrors} onToggle={() => onShowErrorsChange(!showErrors)} />
+            )}
+            <ToggleBtn label="Grid" value={showGrid} onToggle={() => setShowGrid(!showGrid)} />
+            <Menu label="Style">
+              <RadioGroup
+                name="curve-type"
+                label="Curve"
+                options={CURVE_TYPE_OPTIONS}
+                optionsLabels={CURVE_TYPE_LABELS}
+                value={curveType}
+                onChange={setCurveType}
+              />
+              <RadioGroup
+                name="interpolation"
+                label="Interpolation"
+                options={INTERPOLATION_OPTIONS}
+                disabled={curveType === CurveType.GlyphsOnly}
+                value={interpolation}
+                onChange={setInterpolation}
+              />
+            </Menu>
           </Toolbar>
         </Box>
       </Paper>
+
       <LineVis
         dataArray={primaryArray}
-        domain={domain}
+        domain={safeDomain}
         errorsArray={primaryErrorsArray}
         showErrors={showErrors}
         auxiliaries={auxiliaries.length > 0 ? auxiliaries : undefined}
-        showGrid={lineShowGrid}
+        showGrid={showGrid}
         scaleType={yScaleType}
-        abscissaParams={{ scaleType: xScaleType, value: primaryAbscissas }}
+        curveType={curveType}
+        interpolation={interpolation}
+        ordinateLabel="Value"
+        abscissaParams={{ label: 'Index', scaleType: xScaleType, value: primaryAbscissas }}
       />
     </Box>
   );

--- a/src/components/experimentViewer/Viewer2D.tsx
+++ b/src/components/experimentViewer/Viewer2D.tsx
@@ -39,7 +39,7 @@ const Viewer2D: React.FC<Viewer2DProps> = ({ filepath }): JSX.Element => {
             Select a file to view 2D data
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Choose a file from the File Tree to visualize HDF5 datasets in 2D
+            Choose a file from the File tree to visualize HDF5 datasets in 2D
           </Typography>
         </Box>
       </Box>

--- a/src/components/experimentViewer/ViewerTabs.tsx
+++ b/src/components/experimentViewer/ViewerTabs.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Tabs, Tab, Box } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import GridOnIcon from '@mui/icons-material/GridOn';
 
@@ -9,11 +10,40 @@ interface ViewerTabsProps {
 }
 
 const ViewerTabs: React.FC<ViewerTabsProps> = ({ activeTab, onTabChange }): JSX.Element => {
+  const theme = useTheme();
+  const selectedTabColor = theme.palette.mode === 'dark' ? theme.palette.info.light : theme.palette.primary.main;
+  const selectedTabBackground =
+    theme.palette.mode === 'dark' ? alpha(theme.palette.info.light, 0.14) : alpha(theme.palette.primary.main, 0.08);
+
   return (
     <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-      <Tabs value={activeTab} onChange={(_, newTab) => onTabChange(newTab)} variant="fullWidth">
-        <Tab value="1d" label="1D View" icon={<ShowChartIcon />} iconPosition="start" />
-        <Tab value="2d" label="MD View" icon={<GridOnIcon />} iconPosition="start" />
+      <Tabs
+        value={activeTab}
+        onChange={(_: React.SyntheticEvent, newTab: '1d' | '2d') => onTabChange(newTab)}
+        variant="fullWidth"
+        sx={{
+          '& .MuiTabs-indicator': {
+            height: 3,
+            borderRadius: '3px 3px 0 0',
+            backgroundColor: selectedTabColor,
+          },
+          '& .MuiTab-root': {
+            minHeight: 52,
+            textTransform: 'none',
+            fontWeight: 600,
+            color: theme.palette.text.secondary,
+          },
+          '& .MuiTab-root:hover': {
+            backgroundColor: theme.palette.action.hover,
+          },
+          '& .MuiTab-root.Mui-selected': {
+            color: selectedTabColor,
+            backgroundColor: selectedTabBackground,
+          },
+        }}
+      >
+        <Tab value="1d" label="1D view" icon={<ShowChartIcon />} iconPosition="start" />
+        <Tab value="2d" label="MD view" icon={<GridOnIcon />} iconPosition="start" />
       </Tabs>
     </Box>
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,6 +90,7 @@ export interface LinePlotData {
   data: DataArray1D;
   errors?: DataArray1D;
   color?: string;
+  supportsErrors?: boolean;
 }
 
 // Filter for the h5 files to include

--- a/src/pages/ExperimentViewer.tsx
+++ b/src/pages/ExperimentViewer.tsx
@@ -347,6 +347,14 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
     setFiles((prevFiles) => prevFiles.map((file, i) => (i === index ? { ...file, selection: selections } : file)));
   };
 
+  useEffect(() => {
+    const hasEnabledErrorSupport = files.some((file) => file.enabled && file.path && file.errorPath);
+
+    if (showErrors && !hasEnabledErrorSupport) {
+      setShowErrors(false);
+    }
+  }, [files, showErrors]);
+
   // Fetch data for all enabled files with paths selected
   useEffect(() => {
     const enabledFiles = files.filter((file) => file.enabled && file.path);
@@ -389,6 +397,7 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
                   filename: file.filename,
                   data,
                   errors,
+                  supportsErrors: Boolean(file.errorPath),
                 };
               })(),
             ];
@@ -414,6 +423,7 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
                 filename: `${file.filename} [slice ${slice}]`,
                 data,
                 errors,
+                supportsErrors: Boolean(file.errorPath),
               };
             })()
           );


### PR DESCRIPTION
Closes #552, closes #672.

## Description

Implements further experiment viewer customization for 1D plots and fixes dark mode styling.

## Changes

- Tabs, graphs, and menus now more visible in dark mode.
- Add X/Y axis scale switching for 1D plots.
- Add editable Y-domain controls.
- Add curve style options for lines / points / both.
- Add interpolation controls.
- Only show and enable error-bar controls when the selected datasets support errors.
- Track per-series error support in the experiment viewer data flow.
- Keep multi-line plots on a safe combined domain.