### PR TITLE
Use blue text logo when in dark high-contrast mode

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,6 @@
 // Resolve plugin logo at runtime
 const lightLogoUrl = new URL('./images/fia-light-text-logo.png', import.meta.url).href;
+const darkLogoUrl = new URL('./images/fia-dark-text-logo.png', import.meta.url).href;
 
 export function createRoute(
   section: string,
@@ -9,11 +10,6 @@ export function createRoute(
   helpText: string,
   unauthorised: boolean
 ): void {
-  // By default SciGateway will use logoDarkMode even when light mode is on.
-  // Also, switching between light and dark doesn't alter the header bar
-  // colour unless high contrast mode is also on, so for now only using the
-  // light logo
-  const logoUrl = lightLogoUrl;
   const routeAction = {
     type: 'scigateway:api:register_route',
     payload: {
@@ -24,8 +20,8 @@ export function createRoute(
       order: order,
       helpText: helpText,
       unauthorised: unauthorised,
-      logoLightMode: logoUrl,
-      logoDarkMode: logoUrl,
+      logoLightMode: lightLogoUrl,
+      logoDarkMode: darkLogoUrl,
       logoAltText: 'Flexible Interactive Automation',
     },
   };


### PR DESCRIPTION
Closes #160.

## Description
Makes use of the dark mode high-contrast logo.

NOTE: this work requires the following SciGateway PR to be merged and for the frontend to be using the release tied to it:
https://github.com/ral-facilities/scigateway/pull/1617.

## Testing instructions
1. Start SciGateway.
2. Open the plugin and confirm the light logo is shown in light mode.
3. Enable dark mode only and confirm the light logo is still shown.
4. Enable high contrast mode while dark mode is still on and confirm the dark logo is shown.
5. Disable high contrast mode again and confirm the logo switches back to the light version.