### PR TITLE
Upgrade to SciGateway v4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is for the frontend web application side of [FIA](https://github
 
 ### Downloading the code
 
-To get started developing for the frontend, first you will need to have [Node.js](https://nodejs.org/en/download/package-manager) and [Yarn](https://classic.yarnpkg.com/en/docs/install) installed and set-up on your machine. When following the install wizards just keep to default settings. You will then want to clone the [SciGateway](https://github.com/ral-facilities/scigateway) repository. From now on stick to SciGateway's `release/v4.0.0` branch (worth noting that `develop` is the repository's default branch instead of "main" or "master").
+To get started developing for the frontend, first you will need to have [Node.js](https://nodejs.org/en/download/package-manager) and [Yarn](https://classic.yarnpkg.com/en/docs/install) installed and set-up on your machine. When following the install wizards just keep to default settings. You will then want to clone the [SciGateway](https://github.com/ral-facilities/scigateway) repository. From now on stick to SciGateway's `release/v4.1.0` branch (worth noting that `develop` is the repository's default branch instead of "main" or "master").
 
 With that done, you can now clone the FIA frontend repository. This repo includes the `src/h5web` git submodule, which is required for low-level H5Web components.
 
@@ -24,7 +24,7 @@ git submodule update --init --recursive
 
 ### Setting up FIA as a plugin
 
-The frontend works by building the project and then running it through SciGateway as a plugin. You will want to create a `settings.json` file in SciGateway's `public` folder. Do this by simply duplicating [`settings.example.json`](https://github.com/ral-facilities/scigateway/blob/v4.0.0/public/settings.example.json) and renaming it. A few adjustments will need to be made, like adding FIA as a plugin, setting `"homepageUrl"` to `"/fia"`, and pointing the `"authUrl"` to `"https://dev.reduce.isis.cclrc.ac.uk/auth"`. The `"auth-provider"` can be set to `null` or `"jwt"`. Aside from that, keep everything else as is:
+The frontend works by building the project and then running it through SciGateway as a plugin. You will want to create a `settings.json` file in SciGateway's `public` folder. Do this by simply duplicating [`settings.example.json`](https://github.com/ral-facilities/scigateway/blob/release/v4.1.0/public/settings.example.json) and renaming it. A few adjustments will need to be made, like adding FIA as a plugin, setting `"homepageUrl"` to `"/fia"`, and pointing the `"authUrl"` to `"https://dev.reduce.isis.cclrc.ac.uk/auth"`. The `"auth-provider"` can be set to `null` or `"jwt"`. Aside from that, keep everything else as is:
 
 ```json
 // settings.json
@@ -42,7 +42,7 @@ The frontend works by building the project and then running it through SciGatewa
 ]
 ```
 
-A `dev-plugin-settings.json` file is also needed in SciGateway's `micro-frontend-tools` folder. Like before, simply duplicate [`dev-plugin-settings.example.json`](https://github.com/ral-facilities/scigateway/blob/v4.0.0/micro-frontend-tools/dev-plugin-settings.example.json), rename it, and add the path to the FIA frontend build folder:
+A `dev-plugin-settings.json` file is also needed in SciGateway's `micro-frontend-tools` folder. Like before, simply duplicate [`dev-plugin-settings.example.json`](https://github.com/ral-facilities/scigateway/blob/release/v4.1.0/micro-frontend-tools/dev-plugin-settings.example.json), rename it, and add the path to the FIA frontend build folder:
 
 ```json
 // dev-plugin-settings.json

--- a/container/scigateway.dockerfile
+++ b/container/scigateway.dockerfile
@@ -1,12 +1,14 @@
-FROM harbor.stfc.ac.uk/datagateway/scigateway@sha256:b80383f50d4cddb9d6412f38eca97adc88c2611afa19753740028fcd9f03c5cd
 ENV AUTH_URL /auth
 ENV AUTH_PROVIDER jwt
+FROM harbor.stfc.ac.uk/datagateway/scigateway:v4.1.0@sha256:a8c2de9c741d811bb2af7c1483120a37af36957f167ceaba82696ea14d41f7d0
 
 WORKDIR /usr/local/apache2/htdocs
 
 USER root
-# Change the title
+
+# Keep the browser title aligned with FIA branding
 RUN sed -i -e 's/<title>SciGateway<\/title>/<title>FIA<\/title>/' index.html
+
 USER www-data
 
 COPY --chown=www-data:www-data settings.json ./settings.json

--- a/container/scigateway.dockerfile
+++ b/container/scigateway.dockerfile
@@ -1,5 +1,3 @@
-ENV AUTH_URL /auth
-ENV AUTH_PROVIDER jwt
 FROM harbor.stfc.ac.uk/datagateway/scigateway:v4.1.0@sha256:a8c2de9c741d811bb2af7c1483120a37af36957f167ceaba82696ea14d41f7d0
 
 WORKDIR /usr/local/apache2/htdocs


### PR DESCRIPTION
Closes #688.

## Description

Updates the harbor SHA to point to the 4.1 release of SciGateway.

Correct README to reference 4.1.