### PR TITLE
Add experiment viewer spacing

### DIFF
--- a/src/pages/ExperimentViewer.tsx
+++ b/src/pages/ExperimentViewer.tsx
@@ -490,7 +490,16 @@ const ExperimentViewer: React.FC = (): JSX.Element => {
   return (
     <>
       <NavArrows />
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', width: '100%' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100vh',
+          width: '100%',
+          boxSizing: 'border-box',
+          pt: showSearch ? 0 : 2,
+        }}
+      >
         {/* Search bar - only show when not viewing specific job */}
         {showSearch && (
           <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>


### PR DESCRIPTION
Closes #692.

## Description

Adds spacing between the breadcrumbs and viewer when viewing a specific job in the experiment viewer.
