### PR TITLE
Add focused Vitest coverage for frontend utilities and routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
   "devDependencies": {
     "@cypress/react": "^7.0.3",
     "@cypress/webpack-dev-server": "^3.11.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react-router-dom": "5.3.3",
     "@typescript-eslint/eslint-plugin": "8.16.0",
     "@typescript-eslint/parser": "8.16.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import App from './App';
+import { clearFailedAuthRequestsQueue, retryFailedAuthRequests } from './lib/api';
+
+vi.mock('react-ga4', () => ({
+  default: {
+    event: vi.fn(),
+    initialize: vi.fn(),
+    send: vi.fn(),
+  },
+}));
+
+vi.mock('./lib/api', () => ({
+  clearFailedAuthRequestsQueue: vi.fn(),
+  retryFailedAuthRequests: vi.fn(),
+}));
+
+vi.mock('./GlobalStyles', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./pages/Homepage', () => ({
+  default: () => <h1>Homepage</h1>,
+}));
+
+vi.mock('./pages/Instruments', () => ({
+  default: () => <h1>Instruments</h1>,
+}));
+
+vi.mock('./pages/Jobs', () => ({
+  default: () => <h1>Jobs</h1>,
+}));
+
+vi.mock('./pages/ValueEditor', () => ({
+  default: () => <h1>Value editor</h1>,
+}));
+
+vi.mock('./pages/ExperimentViewer', () => ({
+  default: () => <h1>Experiment viewer</h1>,
+}));
+
+vi.mock('./pages/LiveData', () => ({
+  default: () => <h1>Live data</h1>,
+}));
+
+vi.mock('./pages/LiveValueEditor', () => ({
+  default: () => <h1>Live value editor</h1>,
+}));
+
+vi.mock('./pages/DataViewer', () => ({
+  default: () => <h1>Data viewer</h1>,
+}));
+
+function renderAt(path: string): void {
+  window.history.pushState({}, '', path);
+  render(<App />);
+}
+
+describe('App', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.pushState({}, '', '/fia');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders the homepage at the FIA root route', () => {
+    renderAt('/fia');
+
+    expect(screen.getByRole('heading', { name: 'Homepage' })).toBeInTheDocument();
+  });
+
+  test('routes to the instruments page under the FIA basename', () => {
+    renderAt('/fia/instruments');
+
+    expect(screen.getByRole('heading', { name: 'Instruments' })).toBeInTheDocument();
+  });
+
+  test('redirects unmatched FIA routes back to the homepage', async () => {
+    renderAt('/fia/not-a-real-route');
+
+    expect(await screen.findByRole('heading', { name: 'Homepage' })).toBeInTheDocument();
+    expect(window.location.pathname).toMatch(/^\/fia\/?$/);
+  });
+
+  test('handles SciGateway token refresh and signout events', () => {
+    renderAt('/fia');
+
+    act(() => {
+      document.dispatchEvent(new CustomEvent('scigateway', { detail: { type: 'scigateway:api:invalidate_token' } }));
+      document.dispatchEvent(new CustomEvent('scigateway', { detail: { type: 'scigateway:api:signout' } }));
+      document.dispatchEvent(new CustomEvent('scigateway', { detail: { type: 'scigateway:api:plugin_rerender' } }));
+    });
+
+    expect(retryFailedAuthRequests).toHaveBeenCalledTimes(1);
+    expect(clearFailedAuthRequestsQueue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/data-viewer/utils/QueryUrl.test.ts
+++ b/src/components/data-viewer/utils/QueryUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import { FileQueryUrl } from './FileQueryUrl';
+import { TextQueryUrl } from './TextQueryUrl';
+
+describe('data viewer query URL helpers', () => {
+  test('prefers an instrument-scoped file query when instrument and experiment number are present', () => {
+    expect(FileQueryUrl('LOQ', '12345', 'u123')).toBe('find_file/instrument/LOQ/experiment_number/12345');
+  });
+
+  test('builds generic file queries from user or experiment number', () => {
+    expect(FileQueryUrl(undefined, undefined, 'u123')).toBe('find_file/generic/user_number/u123');
+    expect(FileQueryUrl(undefined, '12345')).toBe('find_file/generic/experiment_number/12345');
+    expect(FileQueryUrl()).toBeNull();
+  });
+
+  test('prefers an instrument-scoped text query when instrument and experiment number are present', () => {
+    expect(TextQueryUrl('LOQ', '12345', 'u123')).toBe('/text/instrument/LOQ/experiment_number/12345');
+  });
+
+  test('builds generic text queries from user or experiment number', () => {
+    expect(TextQueryUrl(undefined, undefined, 'u123')).toBe('text/generic/user_number/u123');
+    expect(TextQueryUrl(undefined, '12345')).toBe('text/generic/experiment_number/12345');
+    expect(TextQueryUrl()).toBeNull();
+  });
+});

--- a/src/components/jobs/InstrumentSelector.test.tsx
+++ b/src/components/jobs/InstrumentSelector.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { instruments } from '../../lib/instrumentData';
+import InstrumentSelector from './InstrumentSelector';
+
+describe('InstrumentSelector', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders ALL plus every configured instrument as options', async () => {
+    const user = userEvent.setup();
+
+    render(<InstrumentSelector selectedInstrument="ALL" handleInstrumentChange={vi.fn()} />);
+
+    expect(screen.getByRole('combobox', { name: 'Instrument' })).toHaveTextContent('ALL');
+
+    await user.click(screen.getByRole('combobox', { name: 'Instrument' }));
+
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(instruments.length + 1);
+    expect(screen.getByRole('option', { name: 'ALL' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'LOQ' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'IMAT' })).toBeInTheDocument();
+  });
+
+  test('passes the selected instrument value to the change handler', async () => {
+    const user = userEvent.setup();
+    const handleInstrumentChange = vi.fn();
+
+    render(<InstrumentSelector selectedInstrument="ALL" handleInstrumentChange={handleInstrumentChange} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Instrument' }));
+    await user.click(screen.getByRole('option', { name: 'LOQ' }));
+
+    expect(handleInstrumentChange).toHaveBeenCalledTimes(1);
+    expect(handleInstrumentChange.mock.calls[0][0].target.value).toBe('LOQ');
+  });
+});

--- a/src/components/jobs/constants.test.ts
+++ b/src/components/jobs/constants.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+
+import { isJobRowsPerPage, JOB_ROWS_PER_PAGE_OPTIONS } from './constants';
+
+describe('job table pagination constants', () => {
+  test('accepts every configured rows-per-page option', () => {
+    expect(JOB_ROWS_PER_PAGE_OPTIONS).toEqual([10, 25, 50, 100]);
+    expect(JOB_ROWS_PER_PAGE_OPTIONS.every(isJobRowsPerPage)).toBe(true);
+  });
+
+  test('rejects unsupported row counts', () => {
+    expect(isJobRowsPerPage(0)).toBe(false);
+    expect(isJobRowsPerPage(24)).toBe(false);
+    expect(isJobRowsPerPage(Number.NaN)).toBe(false);
+  });
+});

--- a/src/lib/hooks.test.ts
+++ b/src/lib/hooks.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { parseJobOutputs } from './hooks';
+
+describe('parseJobOutputs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('returns an empty array for missing output values', () => {
+    expect(parseJobOutputs(null)).toEqual([]);
+  });
+
+  test('wraps a single output string in an array', () => {
+    expect(parseJobOutputs('LOQ00012345.nxs')).toEqual(['LOQ00012345.nxs']);
+  });
+
+  test('parses Python-style string arrays returned by the jobs API', () => {
+    expect(parseJobOutputs("['first.nxs', 'second.nxs']")).toEqual(['first.nxs', 'second.nxs']);
+  });
+
+  test('returns an empty array and logs when array output cannot be parsed', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(parseJobOutputs('[not valid json]')).toEqual([]);
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/src/lib/instrumentData.test.ts
+++ b/src/lib/instrumentData.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { instruments, isValidInstrument, VALID_INSTRUMENT_NAMES } from './instrumentData';
+
+describe('instrumentData', () => {
+  test('validates instrument names case-insensitively', () => {
+    expect(isValidInstrument('LOQ')).toBe(true);
+    expect(isValidInstrument('loq')).toBe(true);
+    expect(isValidInstrument('LoQ')).toBe(true);
+  });
+
+  test('rejects missing and unknown instrument names', () => {
+    expect(isValidInstrument(undefined)).toBe(false);
+    expect(isValidInstrument('')).toBe(false);
+    expect(isValidInstrument('NOT_REAL')).toBe(false);
+  });
+
+  test('exports uppercase unique valid instrument names for every instrument', () => {
+    expect(VALID_INSTRUMENT_NAMES).toHaveLength(instruments.length);
+    expect(new Set(VALID_INSTRUMENT_NAMES).size).toBe(VALID_INSTRUMENT_NAMES.length);
+    expect(VALID_INSTRUMENT_NAMES.every((name) => name === name.toUpperCase())).toBe(true);
+    expect(VALID_INSTRUMENT_NAMES).toContain('IMAT');
+    expect(VALID_INSTRUMENT_NAMES).toContain('SANS2D');
+  });
+});

--- a/src/lib/timezone.test.ts
+++ b/src/lib/timezone.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatUtcForLocale } from './timezone';
+
+describe('formatUtcForLocale', () => {
+  test('returns N/A for missing timestamps', () => {
+    expect(formatUtcForLocale(null)).toBe('N/A');
+  });
+
+  test('formats UTC timestamps with the requested locale and options', () => {
+    const options: Intl.DateTimeFormatOptions = {
+      dateStyle: 'short',
+      timeStyle: 'medium',
+      hour12: false,
+      timeZone: 'UTC',
+    };
+
+    expect(formatUtcForLocale('2025-01-02T03:04:05Z', options, 'en-GB')).toBe('02/01/2025 03:04:05');
+  });
+
+  test('treats timestamps without a timezone suffix as UTC', () => {
+    const options: Intl.DateTimeFormatOptions = {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: 'UTC',
+    };
+
+    expect(formatUtcForLocale('2025-01-02T03:04:05', options, 'en-GB')).toBe('03:04');
+  });
+});

--- a/src/routes.test.tsx
+++ b/src/routes.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { createRoute } from './routes';
+
+describe('createRoute', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('dispatches a SciGateway route registration event', () => {
+    const listener = vi.fn();
+    document.addEventListener('scigateway', listener);
+
+    createRoute('Analysis', 'Reduction History', '/fia/reduction-history', 20, 'View reduction jobs', false);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toMatchObject({
+      type: 'scigateway:api:register_route',
+      payload: {
+        section: 'Analysis',
+        link: '/fia/reduction-history',
+        plugin: 'fia',
+        displayName: 'Reduction History',
+        order: 20,
+        helpText: 'View reduction jobs',
+        unauthorised: false,
+        logoAltText: 'Flexible Interactive Automation',
+      },
+    });
+    expect(event.detail.payload.logoLightMode).toContain('fia-light-text-logo');
+    expect(event.detail.payload.logoDarkMode).toBe(event.detail.payload.logoLightMode);
+
+    document.removeEventListener('scigateway', listener);
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom/vitest';
+
 // below required as work-around for enzyme/jest environment not implementing window.URL.createObjectURL method
 function noOp() {}
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,5 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// jest-dom adds custom Vitest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.4.4
+  resolution: "@adobe/css-tools@npm:4.4.4"
+  checksum: 452b82cd9f42aacc57eeaf0b11e36c6864eb482e8a347054cb986503d221d1f7c1418710d2007858d8919afdbd31357149c2c16bd080ded15506f13608d16cf2
+  languageName: node
+  linkType: hard
+
 "@alloc/quick-lru@npm:^5.2.0":
   version: 5.2.0
   resolution: "@alloc/quick-lru@npm:5.2.0"
@@ -4252,6 +4259,65 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^5.0.1
+    aria-query: 5.3.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.5.0
+    picocolors: 1.1.1
+    pretty-format: ^27.0.2
+  checksum: 3887fe95594b6d9467a804e2cc82e719c57f4d55d7d9459b72a949b3a8189db40375b89034637326d4be559f115abc6b6bcfcc6fec0591c4a4d4cdde96751a6c
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^6.9.1":
+  version: 6.9.1
+  resolution: "@testing-library/jest-dom@npm:6.9.1"
+  dependencies:
+    "@adobe/css-tools": ^4.4.0
+    aria-query: ^5.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.6.3
+    picocolors: ^1.1.1
+    redent: ^3.0.0
+  checksum: 5c77126a59a1c0df5935d29569652364c56e5026982f0357f0daaeb21b75fcd9a6aeff8365bdcba719687a4359b3f8bf74bba81ccbae7635cf18ad9789e1e323
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^16.3.2":
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 1f6f4d8374aab54214229eecdd429d5e878e902c6136a48e187a24d4917014bf91ab9aa7fab18c17f6bf05f226fac228ba9a5c1803657129173dd8a062139c17
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 4cb8a81fea1fea83a42619e9545137b51636bb7a3182c596bb468e5664f1e4699a275c2d0fb8b6dcc3fe2684f9d87b0637ab7cb4f566051539146872c9141fcb
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:1":
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
@@ -4263,6 +4329,13 @@ __metadata:
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
   checksum: 11226c39b52b391719a2a92e10183e4260d9651f86edced166da1d95f39a0a1eaa470e44d14ac685ccd6d3df7e2002433782872c0feeb260d61e80f21250e65c
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: ad8b87e4ad64255db5f0a73bc2b4da9b146c38a3a8ab4d9306154334e0fc67ae64e76bfa298eebd1e71830591fb15987e5de7111bdb36a2221bdc379e3415fb0
   languageName: node
   linkType: hard
 
@@ -6143,7 +6216,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.3.2":
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: ^2.0.3
+  checksum: 305bd73c76756117b59aba121d08f413c7ff5e80fa1b98e217a3443fcddb9a232ee790e24e432b59ae7625aebcf4c47cb01c2cac872994f0b426f5bdfcd96ba9
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: d971175c85c10df0f6d14adfe6f1292409196114ab3c62f238e208b53103686f46cc70695a4f775b73bc65f6a09b6a092fd963c4f3a5a7d690c8fc5094925717
@@ -7835,6 +7917,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "cssdb@npm:^7.1.0":
   version: 7.11.2
   resolution: "cssdb@npm:7.11.2"
@@ -8371,6 +8460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
+  languageName: node
+  linkType: hard
+
 "destroy@npm:1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
@@ -8466,6 +8562,20 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: c325b5144bb406df23f4affecffc117dbaec9af03daad9ee6b510c5be647b14d28ef0a4ea5ca06d696d8ab40bb777e5fed98b985976fdef9d8790178fa1d573f
   languageName: node
   linkType: hard
 
@@ -9985,6 +10095,10 @@ __metadata:
     "@mui/material": ^6.0.0
     "@mui/x-date-pickers": ^7.27.0
     "@react-three/fiber": 8.18.0
+    "@testing-library/dom": ^10.4.1
+    "@testing-library/jest-dom": ^6.9.1
+    "@testing-library/react": ^16.3.2
+    "@testing-library/user-event": ^14.6.1
     "@types/jest": 29.5.14
     "@types/node": 22.10.0
     "@types/react": 18.3.11
@@ -13283,6 +13397,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 1ee98b4580246fd90dd54da6e346fb1caefcf05f677c686d9af237a157fdea3fd7c83a4bc58f858cd5b10a34d27afe0fdcbd0505a47e0590726a873dc8b8f65d
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.25.0, magic-string@npm:^0.25.7":
   version: 0.25.9
   resolution: "magic-string@npm:0.25.9"
@@ -13507,6 +13630,13 @@ __metadata:
   version: 5.0.1
   resolution: "mimic-function@npm:5.0.1"
   checksum: eb5893c99e902ccebbc267c6c6b83092966af84682957f79313311edb95e8bb5f39fb048d77132b700474d1c86d90ccc211e99bae0935447a4834eb4c882982c
+  languageName: node
+  linkType: hard
+
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
   languageName: node
   linkType: hard
 
@@ -14404,17 +14534,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^0.2.1":
   version: 0.2.1
   resolution: "picocolors@npm:0.2.1"
   checksum: 3b0f441f0062def0c0f39e87b898ae7461c3a16ffc9f974f320b44c799418cabff17780ee647fda42b856a1dc45897e2c62047e1b546d94d6d5c6962f45427b2
-  languageName: node
-  linkType: hard
-
-"picocolors@npm:^1.0.0, picocolors@npm:^1.0.1, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "picocolors@npm:1.1.1"
-  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
   languageName: node
   linkType: hard
 
@@ -15412,7 +15542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.5.1":
+"pretty-format@npm:^27.0.2, pretty-format@npm:^27.5.1":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
   dependencies:
@@ -16098,6 +16228,16 @@ __metadata:
   dependencies:
     minimatch: ^3.0.5
   checksum: 88ec96e276237290607edc0872b4f9842837b95cfde0cdbb1e00ba9623dfdf3514d44cdd14496ab60a0c2dd180a6ef8a3f1c34599e6cf2273afac9b72a6fb2b5
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: ^4.0.0
+    strip-indent: ^3.0.0
+  checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 
@@ -17597,6 +17737,15 @@ __metadata:
   version: 3.0.0
   resolution: "strip-final-newline@npm:3.0.0"
   checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: ^1.0.0
+  checksum: 18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes None.

## Summary
- Added Testing Library support for Vitest component tests.
- Added focused unit coverage for frontend helpers including timezone formatting, instrument validation, query URL builders, job output parsing, route registration, and job pagination constants.
- Added component coverage for `App` routing/SciGateway event handling and `InstrumentSelector`.

## Verification
- `npm exec -- vitest run --coverage` passes: 9 test files, 25 tests.
- Coverage increased from 3.43% to 11.02%.
