### PR TITLE
Bump SciGateway Docker image to v4.1.1

### DIFF
--- a/container/scigateway.dockerfile
+++ b/container/scigateway.dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.stfc.ac.uk/datagateway/scigateway:v4.1.0@sha256:a8c2de9c741d811bb2af7c1483120a37af36957f167ceaba82696ea14d41f7d0
+FROM harbor.stfc.ac.uk/datagateway/scigateway:v4.1.1@sha256:f8072c9ea738a2e97d998d7b629d6998de949c15f18ccca0950f1388b2e7c71f
 
 WORKDIR /usr/local/apache2/htdocs
 

--- a/src/routes.test.tsx
+++ b/src/routes.test.tsx
@@ -28,8 +28,8 @@ describe('createRoute', () => {
         logoAltText: 'Flexible Interactive Automation',
       },
     });
-    expect(event.detail.payload.logoLightMode).toContain('fia-light-text-logo');
-    expect(event.detail.payload.logoDarkMode).toBe(event.detail.payload.logoLightMode);
+    expect(event.detail.payload.logoLightMode).toContain('fia-dark-text-logo');
+    expect(event.detail.payload.logoDarkMode).toContain('fia-light-text-logo');
 
     document.removeEventListener('scigateway', listener);
   });

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,6 @@
 // Resolve plugin logo at runtime
-const lightLogoUrl = new URL('./images/fia-light-text-logo.png', import.meta.url).href;
-const darkLogoUrl = new URL('./images/fia-dark-text-logo.png', import.meta.url).href;
+const logoDarkMode = new URL('./images/fia-light-text-logo.png', import.meta.url).href;
+const logoLightMode = new URL('./images/fia-dark-text-logo.png', import.meta.url).href;
 
 export function createRoute(
   section: string,
@@ -20,8 +20,8 @@ export function createRoute(
       order: order,
       helpText: helpText,
       unauthorised: unauthorised,
-      logoLightMode: lightLogoUrl,
-      logoDarkMode: darkLogoUrl,
+      logoLightMode: logoLightMode,
+      logoDarkMode: logoDarkMode,
       logoAltText: 'Flexible Interactive Automation',
     },
   };


### PR DESCRIPTION
Closes None.

## Description

Bumps SciGateway version from 4.1.0 to 4.1.1. Includes a Node security update.

Fixes logo name spaces which were the wrong way round for light/dark mode.
