### PR TITLE
Increase frontend coverage

### DIFF
--- a/src/components/configsettings/FileUploader.test.tsx
+++ b/src/components/configsettings/FileUploader.test.tsx
@@ -1,0 +1,98 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import FileUploader from './FileUploader';
+import { fiaApi } from '../../lib/api';
+
+import type { ChangeEvent } from 'react';
+
+vi.mock('../../lib/api', () => ({
+  fiaApi: {
+    post: vi.fn(),
+  },
+}));
+
+function fileSelectionEvent(file: File | null): ChangeEvent<HTMLInputElement> {
+  return {
+    target: {
+      files: file ? [file] : null,
+    },
+  } as unknown as ChangeEvent<HTMLInputElement>;
+}
+
+describe('FileUploader', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  test('stores the selected file and exposes a selection message', () => {
+    const file = new File(['print("reduce")'], 'reduce.py', { type: 'text/x-python' });
+    const { result } = renderHook(() => FileUploader('/extras/loq'));
+
+    act(() => {
+      result.current.handleFileSelection(fileSelectionEvent(file));
+    });
+
+    expect(result.current.selectedFile).toBe(file);
+    expect(result.current.uploadMessage).toBe('Selected file: reduce.py');
+  });
+
+  test('clears the selection message when the file input has no files', () => {
+    const { result } = renderHook(() => FileUploader('/extras/loq'));
+
+    act(() => {
+      result.current.handleFileSelection(fileSelectionEvent(null));
+    });
+
+    expect(result.current.selectedFile).toBeNull();
+    expect(result.current.uploadMessage).toBe('');
+  });
+
+  test('uploads the selected file to the instrument-specific endpoint', async () => {
+    const file = new File(['script contents'], 'loq_reduction.py', { type: 'text/x-python' });
+    const { result } = renderHook(() => FileUploader('/extras/loq'));
+
+    vi.mocked(fiaApi.post).mockResolvedValue({ data: {} });
+
+    act(() => {
+      result.current.handleFileSelection(fileSelectionEvent(file));
+    });
+
+    await act(async () => {
+      await result.current.handleFileUpload();
+    });
+
+    expect(fiaApi.post).toHaveBeenCalledWith('/extras/loq/loq_reduction.py', expect.any(FormData));
+
+    const formData = vi.mocked(fiaApi.post).mock.calls[0][1] as FormData;
+    expect(formData.get('file')).toBe(file);
+    expect(result.current.uploadMessage).toBe('Uploaded file: loq_reduction.py');
+  });
+
+  test('does not post when no file has been selected', async () => {
+    const { result } = renderHook(() => FileUploader('/extras/loq'));
+
+    await act(async () => {
+      await result.current.handleFileUpload();
+    });
+
+    expect(fiaApi.post).not.toHaveBeenCalled();
+  });
+
+  test('logs upload failures and rejects with a user-facing error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const file = new File(['script contents'], 'loq_reduction.py', { type: 'text/x-python' });
+    const uploadError = new Error('upload failed');
+    const { result } = renderHook(() => FileUploader('/extras/loq'));
+
+    vi.mocked(fiaApi.post).mockRejectedValue(uploadError);
+
+    act(() => {
+      result.current.handleFileSelection(fileSelectionEvent(file));
+    });
+
+    await expect(result.current.handleFileUpload()).rejects.toThrow('Failed to upload the file');
+    expect(consoleError).toHaveBeenCalledWith('Error uploading file:', uploadError);
+  });
+});

--- a/src/components/configsettings/UploadButton.test.tsx
+++ b/src/components/configsettings/UploadButton.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import UploadButton from './UploadButton';
+
+vi.mock('@mui/icons-material', () => ({
+  Edit: () => null,
+  UploadFile: () => null,
+}));
+
+describe('UploadButton', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders upload and disabled edit controls without a selection message', () => {
+    const { container } = render(<UploadButton onChange={vi.fn()} selectedFile={null} uploadMessage="Selected file" />);
+
+    expect(screen.getByRole('button', { name: /select file to upload/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /change script/i })).toBeDisabled();
+    expect(screen.queryByText('Selected file')).not.toBeInTheDocument();
+
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toHaveAttribute('multiple');
+  });
+
+  test('shows the upload message once a file is selected', () => {
+    const file = new File(['script contents'], 'script.py');
+
+    render(<UploadButton onChange={vi.fn()} selectedFile={file} uploadMessage="Selected file: script.py" />);
+
+    expect(screen.getByText('Selected file: script.py')).toBeInTheDocument();
+  });
+
+  test('forwards file input changes to the supplied handler', () => {
+    const onChange = vi.fn();
+    const file = new File(['script contents'], 'script.py');
+    const { container } = render(<UploadButton onChange={onChange} selectedFile={null} uploadMessage="" />);
+    const input = container.querySelector('input[type="file"]');
+
+    if (!input) {
+      throw new Error('Expected upload input to be rendered');
+    }
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/data-viewer/utils/FallbackPage.test.tsx
+++ b/src/components/data-viewer/utils/FallbackPage.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { Fallback } from './FallbackPage';
+
+describe('Fallback', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders the error state with recovery and support links', () => {
+    render(<Fallback />);
+
+    expect(screen.getByRole('img', { name: 'Monkey holding excellent website award' })).toHaveAttribute(
+      'src',
+      '/res/images/monkey.webp'
+    );
+    expect(screen.getByRole('heading', { name: 'Something Went Wrong' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', 'https://reduce.isis.cclrc.ac.uk');
+    expect(screen.getByRole('link', { name: 'fia-support' })).toHaveAttribute('href', 'mailto:fia@stfc.ac.uk');
+  });
+});

--- a/src/components/navigation/NavArrows.test.tsx
+++ b/src/components/navigation/NavArrows.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import NavArrows from './NavArrows';
+
+function renderAt(path: string): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <NavArrows />
+    </MemoryRouter>
+  );
+}
+
+describe('NavArrows', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders nothing at the root route', () => {
+    const { container } = renderAt('/');
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders normalized breadcrumb labels and intermediate links', () => {
+    renderAt('/instruments/LOQ/experiment-viewer-123/value-editor-456');
+
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' }));
+
+    expect(breadcrumbs.getByRole('link', { name: 'FIA' })).toHaveAttribute('href', '/');
+    expect(breadcrumbs.getByRole('link', { name: 'Instruments' })).toHaveAttribute('href', '/instruments');
+    expect(breadcrumbs.getByRole('link', { name: 'LOQ' })).toHaveAttribute('href', '/instruments/LOQ');
+    expect(breadcrumbs.getByRole('link', { name: 'Experiment viewer' })).toHaveAttribute(
+      'href',
+      '/instruments/LOQ/experiment-viewer-123'
+    );
+    expect(breadcrumbs.getByText('Value editor')).toBeInTheDocument();
+    expect(breadcrumbs.queryByRole('link', { name: 'Value editor' })).not.toBeInTheDocument();
+  });
+
+  test('decodes path segments before rendering breadcrumb text', () => {
+    renderAt('/live-data/sample%20run');
+
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' }));
+
+    expect(breadcrumbs.getByRole('link', { name: 'Live data' })).toHaveAttribute('href', '/live-data');
+    expect(breadcrumbs.getByText('sample run')).toBeInTheDocument();
+  });
+});

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { clearFailedAuthRequestsQueue, fiaApi, h5Api, retryFailedAuthRequests } from './api';
+
+import type { AxiosAdapter, AxiosError, InternalAxiosRequestConfig } from 'axios';
+
+type RequestFulfilled = (
+  config: InternalAxiosRequestConfig
+) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
+
+type ResponseRejected = (error: AxiosError) => Promise<unknown>;
+
+type RequestInterceptorHandler = {
+  fulfilled?: RequestFulfilled;
+};
+
+type ResponseInterceptorHandler = {
+  rejected?: ResponseRejected;
+};
+
+type InterceptorStore<THandler> = {
+  handlers: Array<THandler | null>;
+};
+
+const originalFiaAdapter = fiaApi.defaults.adapter;
+
+function getRequestFulfilled(api: typeof fiaApi): RequestFulfilled {
+  const store = api.interceptors.request as unknown as InterceptorStore<RequestInterceptorHandler>;
+  const fulfilled = store.handlers.find((handler) => handler?.fulfilled)?.fulfilled;
+
+  if (!fulfilled) {
+    throw new Error('Expected request interceptor to be registered');
+  }
+
+  return fulfilled;
+}
+
+function getResponseRejected(api: typeof fiaApi): ResponseRejected {
+  const store = api.interceptors.response as unknown as InterceptorStore<ResponseInterceptorHandler>;
+  const rejected = store.handlers.find((handler) => handler?.rejected)?.rejected;
+
+  if (!rejected) {
+    throw new Error('Expected response interceptor to be registered');
+  }
+
+  return rejected;
+}
+
+function createForbiddenError(url: string): AxiosError {
+  return {
+    config: {
+      headers: {},
+      url,
+    } as InternalAxiosRequestConfig,
+    response: {
+      status: 403,
+    },
+  } as AxiosError;
+}
+
+function createAdapter(): AxiosAdapter {
+  return vi.fn(async (config) => ({
+    config,
+    data: { retried: true },
+    headers: {},
+    status: 200,
+    statusText: 'OK',
+  }));
+}
+
+describe('api interceptors', () => {
+  afterEach(() => {
+    clearFailedAuthRequestsQueue();
+    fiaApi.defaults.adapter = originalFiaAdapter;
+    vi.restoreAllMocks();
+  });
+
+  test('sets the FIA API base URL and authorization header for requests', async () => {
+    const config = await getRequestFulfilled(fiaApi)({ headers: {} } as InternalAxiosRequestConfig);
+    const headers = config.headers as unknown as Record<string, string>;
+
+    expect(config.baseURL).toBe('/api');
+    expect(headers.Authorization).toBe('Bearer ');
+  });
+
+  test('sets the plotting API base URL and trims trailing slashes from request URLs', async () => {
+    const config = await getRequestFulfilled(h5Api)({
+      headers: {},
+      url: '/datasets/?filename=LOQ.nxs',
+    } as InternalAxiosRequestConfig);
+    const headers = config.headers as unknown as Record<string, string>;
+
+    expect(config.baseURL).toBe('/plottingapi');
+    expect(config.url).toBe('/datasets?filename=LOQ.nxs');
+    expect(headers.Authorization).toBe('Bearer ');
+  });
+
+  test('dispatches one token invalidation event and retries queued auth failures after refresh', async () => {
+    const adapter = createAdapter();
+    const listener = vi.fn();
+
+    fiaApi.defaults.adapter = adapter;
+    document.addEventListener('scigateway', listener as EventListener);
+
+    const rejected = getResponseRejected(fiaApi);
+    const firstRetry = rejected(createForbiddenError('/jobs/1'));
+    const secondRetry = rejected(createForbiddenError('/jobs/2'));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      type: 'scigateway:api:invalidate_token',
+    });
+
+    retryFailedAuthRequests();
+
+    await expect(firstRetry).resolves.toMatchObject({ data: { retried: true } });
+    await expect(secondRetry).resolves.toMatchObject({ data: { retried: true } });
+    expect(adapter).toHaveBeenCalledTimes(2);
+
+    document.removeEventListener('scigateway', listener as EventListener);
+  });
+
+  test('rejects queued auth failures when SciGateway signs out', async () => {
+    const adapter = createAdapter();
+    const rejected = getResponseRejected(fiaApi);
+    const error = createForbiddenError('/jobs/1');
+
+    fiaApi.defaults.adapter = adapter;
+
+    const retry = rejected(error);
+
+    clearFailedAuthRequestsQueue();
+
+    await expect(retry).rejects.toBe(error);
+    expect(adapter).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-auth response errors immediately', async () => {
+    const rejected = getResponseRejected(fiaApi);
+    const error = {
+      config: { headers: {}, url: '/jobs/1' } as InternalAxiosRequestConfig,
+      response: { status: 500 },
+    } as AxiosError;
+
+    await expect(rejected(error)).rejects.toBe(error);
+  });
+});

--- a/src/lib/hooks.test.ts
+++ b/src/lib/hooks.test.ts
@@ -1,10 +1,22 @@
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { parseJobOutputs } from './hooks';
+import { fiaApi } from './api';
+import { parseJobOutputs, useFetchJobs, useFetchTotalCount } from './hooks';
+
+import type { Job } from './types';
+import type { Dispatch, SetStateAction } from 'react';
+
+vi.mock('./api', () => ({
+  fiaApi: {
+    get: vi.fn(),
+  },
+}));
 
 describe('parseJobOutputs', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   test('returns an empty array for missing output values', () => {
@@ -24,5 +36,84 @@ describe('parseJobOutputs', () => {
 
     expect(parseJobOutputs('[not valid json]')).toEqual([]);
     expect(consoleError).toHaveBeenCalled();
+  });
+});
+
+describe('useFetchJobs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  test('fetches jobs with the supplied query string and stores the response data', async () => {
+    const jobs = [{ id: 1 }] as Job[];
+    const setJobs = vi.fn() as Dispatch<SetStateAction<Job[]>>;
+
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: jobs });
+
+    const { result } = renderHook(() => useFetchJobs('/jobs', 'limit=25&page=2', setJobs));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(fiaApi.get).toHaveBeenCalledWith('/jobs?limit=25&page=2');
+    expect(setJobs).toHaveBeenCalledWith(jobs);
+  });
+
+  test('logs fetch failures without updating jobs', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const setJobs = vi.fn() as Dispatch<SetStateAction<Job[]>>;
+    const error = new Error('request failed');
+
+    vi.mocked(fiaApi.get).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useFetchJobs('/jobs', 'limit=25', setJobs));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(setJobs).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith('Error fetching jobs:', error);
+  });
+});
+
+describe('useFetchTotalCount', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  test('fetches the total row count and stores the count value', async () => {
+    const setTotalRows = vi.fn() as Dispatch<SetStateAction<number>>;
+
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: { count: 42 } });
+
+    const { result } = renderHook(() => useFetchTotalCount('/jobs/count', 'instrument=LOQ', setTotalRows));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(fiaApi.get).toHaveBeenCalledWith('/jobs/count?instrument=LOQ');
+    expect(setTotalRows).toHaveBeenCalledWith(42);
+  });
+
+  test('logs count fetch failures without updating the total', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const setTotalRows = vi.fn() as Dispatch<SetStateAction<number>>;
+    const error = new Error('count failed');
+
+    vi.mocked(fiaApi.get).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useFetchTotalCount('/jobs/count', 'instrument=LOQ', setTotalRows));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(setTotalRows).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith('Error fetching row count:', error);
   });
 });

--- a/src/pages/Homepage.test.tsx
+++ b/src/pages/Homepage.test.tsx
@@ -1,0 +1,58 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import Homepage from './Homepage';
+
+vi.mock('@mui/icons-material/OpenInNew', () => ({
+  default: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTranslation: () => [(key: string) => key],
+}));
+
+function renderHomepage(): void {
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <MemoryRouter>
+        <Homepage />
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+describe('Homepage', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders the primary homepage content and navigation actions', () => {
+    renderHomepage();
+
+    expect(screen.getByText(/Data reduction/)).toBeInTheDocument();
+    expect(screen.getByText(/large-scale/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'Reduce and perform basic analysis remotely from a clean web interface',
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: "View FIA's data reductions" })).toHaveAttribute(
+      'href',
+      '/reduction-history'
+    );
+    expect(screen.getByRole('link', { name: 'Browse instruments' })).toHaveAttribute('href', '/instruments');
+    expect(screen.getByRole('link', { name: 'Read more' })).toHaveAttribute(
+      'href',
+      'https://www.isis.stfc.ac.uk/Pages/About.aspx'
+    );
+    expect(screen.getByRole('link', { name: 'Instrument info' })).toHaveAttribute(
+      'href',
+      'https://www.isis.stfc.ac.uk/Pages/Instruments.aspx'
+    );
+  });
+});

--- a/src/pages/Instruments.test.tsx
+++ b/src/pages/Instruments.test.tsx
@@ -1,0 +1,75 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import Instruments from './Instruments';
+
+vi.mock('@mui/icons-material/ExpandMore', () => ({
+  default: () => null,
+}));
+
+vi.mock('@mui/icons-material/Star', () => ({
+  default: () => null,
+}));
+
+vi.mock('@mui/icons-material/StarBorder', () => ({
+  default: () => null,
+}));
+
+function renderInstruments(): void {
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <MemoryRouter initialEntries={['/instruments']}>
+        <Instruments />
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+}
+
+describe('Instruments', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  test('renders configured instruments and expands instrument details', async () => {
+    const user = userEvent.setup();
+
+    renderInstruments();
+
+    expect(screen.getByRole('heading', { name: 'ISIS instruments' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'LOQ' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'IMAT' })).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole('button', { name: 'show more' })[0]);
+
+    expect(screen.getByText('Scientists:')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'https://www.isis.stfc.ac.uk/Pages/ALF.aspx' })).toHaveAttribute(
+      'href',
+      'https://www.isis.stfc.ac.uk/Pages/ALF.aspx'
+    );
+    expect(screen.getByRole('link', { name: 'Reduction history' })).toHaveAttribute('href', '/reduction-history/ALF');
+  });
+
+  test('loads favorite instruments from storage and persists favorite changes', async () => {
+    const user = userEvent.setup();
+
+    localStorage.setItem('favoriteInstruments', JSON.stringify([17]));
+
+    renderInstruments();
+
+    const headings = screen.getAllByRole('heading', { level: 1 }).map((heading) => heading.textContent);
+    expect(headings.slice(0, 2)).toEqual(['ISIS instruments', 'LOQ']);
+
+    await user.click(screen.getAllByRole('button', { name: 'add to favorites' })[0]);
+
+    expect(localStorage.getItem('favoriteInstruments')).toBe('[]');
+  });
+});


### PR DESCRIPTION
Closes # <!-- Issue # here -->

## Description
- Added frontend tests for upload controls, fallback UI, breadcrumbs, Homepage, Instruments, API auth interceptors, and job-fetching hooks.
- Increased Vitest coverage to >20%.

## Testing
- `yarn vitest run --coverage`