### PR TITLE
Scroll to top on route changes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -62,11 +62,14 @@ function renderAt(path: string): void {
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
     window.history.pushState({}, '', '/fia');
   });
 
   afterEach(() => {
     cleanup();
+    document.getElementById('app-scroll-test-host')?.remove();
+    vi.restoreAllMocks();
   });
 
   test('renders the homepage at the FIA root route', () => {
@@ -79,6 +82,48 @@ describe('App', () => {
     renderAt('/fia/isis-instruments');
 
     expect(screen.getByRole('heading', { name: 'ISIS instruments' })).toBeInTheDocument();
+  });
+
+  test('scrolls to the top when the pathname changes', async () => {
+    renderAt('/fia');
+    vi.mocked(window.scrollTo).mockClear();
+
+    act(() => {
+      window.history.pushState({}, '', '/fia/isis-instruments');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+
+    expect(await screen.findByRole('heading', { name: 'ISIS instruments' })).toBeInTheDocument();
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' });
+  });
+
+  test('scrolls the nearest scrollable container when hosted in SciGateway', async () => {
+    const scrollContainer = document.createElement('div');
+    const pluginWrapper = document.createElement('div');
+    const pluginRoot = document.createElement('div');
+    const scrollContainerScrollTo = vi.fn();
+
+    scrollContainer.id = 'app-scroll-test-host';
+    scrollContainer.style.overflowY = 'auto';
+    Object.defineProperty(scrollContainer, 'scrollTo', { configurable: true, value: scrollContainerScrollTo });
+    pluginRoot.id = 'fia';
+    pluginWrapper.appendChild(pluginRoot);
+    scrollContainer.appendChild(pluginWrapper);
+    document.body.appendChild(scrollContainer);
+
+    render(<App />, { container: pluginRoot });
+    scrollContainerScrollTo.mockClear();
+    vi.mocked(window.scrollTo).mockClear();
+
+    act(() => {
+      window.history.pushState({}, '', '/fia/isis-instruments');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+
+    expect(await screen.findByRole('heading', { name: 'ISIS instruments' })).toBeInTheDocument();
+    expect(scrollContainerScrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' });
+    expect(window.scrollTo).not.toHaveBeenCalled();
   });
 
   test('routes to IMAT image views under reduction history', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import React, { FC } from 'react';
 import ReactGA from 'react-ga4';
-import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Redirect, Route, Switch, useLocation } from 'react-router-dom';
 
 import GlobalStyles from './GlobalStyles';
 import { clearFailedAuthRequestsQueue, retryFailedAuthRequests } from './lib/api';
@@ -20,6 +20,40 @@ import ValueEditor from './pages/ValueEditor';
 ReactGA.initialize('G-7XJBCP6P75');
 // Track the initial page load event
 ReactGA.send({ hitType: 'pageview', page: window.location.pathname });
+
+const scrollableOverflowValues = new Set(['auto', 'scroll', 'overlay']);
+
+const findScrollableAncestor = (element: HTMLElement | null): HTMLElement | null => {
+  let currentElement = element;
+
+  while (currentElement && currentElement !== document.body && currentElement !== document.documentElement) {
+    if (scrollableOverflowValues.has(window.getComputedStyle(currentElement).overflowY)) {
+      return currentElement;
+    }
+
+    currentElement = currentElement.parentElement;
+  }
+
+  return null;
+};
+
+const ScrollToTop: FC = () => {
+  const { pathname } = useLocation();
+
+  React.useLayoutEffect(() => {
+    // SciGateway scrolls a container around the plugin; standalone mode scrolls the window.
+    const scrollContainer = findScrollableAncestor(document.getElementById('fia'));
+    const scrollOptions: ScrollToOptions = { top: 0, left: 0, behavior: 'auto' };
+
+    if (scrollContainer) {
+      scrollContainer.scrollTo(scrollOptions);
+    } else {
+      window.scrollTo(scrollOptions);
+    }
+  }, [pathname]);
+
+  return null;
+};
 
 const App: FC = () => {
   // Force update mechanism using React's useReducer hook
@@ -62,6 +96,7 @@ const App: FC = () => {
     <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={'en-gb'}>
       <GlobalStyles>
         <Router basename="/fia">
+          <ScrollToTop />
           <Switch>
             <Route exact path="/">
               <Homepage />


### PR DESCRIPTION
Closes #739.

## Context

FIA uses client-side routing, so navigating between pages updates the URL and replaces the page content without loading a new document. Because no scroll-restoration logic was present, the existing scroll position was retained after navigation.

When FIA runs within SciGateway, the scrollbar also belongs to SciGateway’s content container rather than the browser window, so resetting only `window.scrollY` would not resolve the issue in production.

## Changes

- Reset the scroll position to the top whenever the route pathname changes.
- Detect and reset SciGateway’s scrollable parent container.
- Fall back to the browser window when running FIA standalone.
- Avoid resetting for query-only changes such as filters and pagination.
- Add tests.

## Notes:

May refactor this out this in the future so there's no window scrollbar. Will make things like the stickyheaders for the reduction table flow better.
