### PR TITLE
Replace OIDC usage with Codecov token for coverage upload

### DIFF
--- a/.github/workflows/yarn_build.yml
+++ b/.github/workflows/yarn_build.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/yarn_build.yml
+++ b/.github/workflows/yarn_build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           disable_search: true
           fail_ci_if_error: true


### PR DESCRIPTION
Switch to token for Codecov.
