### PR TITLE
Refactor stack viewer page

### DIFF
--- a/cypress/e2e/reduction-history.cy.ts
+++ b/cypress/e2e/reduction-history.cy.ts
@@ -330,8 +330,8 @@ describe('Reduction history page', () => {
     cy.wait('@listImatImages');
     cy.contains('newest-frame.tif').should('be.visible');
 
-    cy.contains('button', 'Experiment 13579').click();
-    cy.contains('button', 'IMAT00000301').click();
+    cy.contains('[role="button"]', 'Experiment 13579').click();
+    cy.contains('[role="button"]', 'IMAT00000301').click();
 
     cy.location('search').should('include', 'jobId=301').and('include', 'experiment=13579');
     cy.wait('@findImatStack');

--- a/cypress/e2e/reduction-history.cy.ts
+++ b/cypress/e2e/reduction-history.cy.ts
@@ -53,6 +53,41 @@ const loqJobsResponse = [
   },
 ];
 
+const imatJobsResponse = [
+  {
+    ...baseJob,
+    id: 302,
+    outputs: '/output/run-302',
+    run: {
+      experiment_number: 24680,
+      filename: '/archive/IMAT00000302.raw',
+      run_start: '2025-01-03T09:00:00Z',
+      run_end: '2025-01-03T09:30:00Z',
+      title: 'Newest IMAT stack',
+      users: 'Dr. Curie',
+      good_frames: 500,
+      raw_frames: 500,
+      instrument_name: 'IMAT',
+    },
+  },
+  {
+    ...baseJob,
+    id: 301,
+    outputs: '/output/run-301',
+    run: {
+      experiment_number: 13579,
+      filename: '/archive/IMAT00000301.raw',
+      run_start: '2025-01-02T09:00:00Z',
+      run_end: '2025-01-02T09:30:00Z',
+      title: 'Older IMAT stack',
+      users: 'Dr. Franklin',
+      good_frames: 500,
+      raw_frames: 500,
+      instrument_name: 'IMAT',
+    },
+  },
+];
+
 const tableContainerSelector = '[data-testid="reduction-history-table-container"]';
 
 describe('Reduction history page', () => {
@@ -261,5 +296,46 @@ describe('Reduction history page', () => {
         cy.contains('button', 'Stack viewer').should('have.attr', 'aria-pressed', 'false');
       });
     });
+  });
+
+  it('selects different IMAT stacks from the job tree', () => {
+    cy.intercept('GET', /\/api\/instrument\/IMAT\/jobs\?.*$/, {
+      statusCode: 200,
+      body: imatJobsResponse,
+    }).as('getImatStacks');
+
+    cy.intercept('GET', /\/plottingapi\/find_file\/instrument\/IMAT\/experiment_number\/\d+\?.*$/, {
+      statusCode: 200,
+      body: '/data/imat',
+    }).as('findImatStack');
+
+    cy.intercept('GET', /\/plottingapi\/imat\/list-images\?.*$/, (req) => {
+      const path = String(req.query.path);
+      req.reply({
+        statusCode: 200,
+        body: [path.includes('run-302') ? 'newest-frame.tif' : 'older-frame.tif'],
+      });
+    }).as('listImatImages');
+
+    cy.intercept('GET', /\/plottingapi\/imat\/image\?.*$/, {
+      statusCode: 500,
+      body: 'Image rendering is outside this navigation test',
+    });
+
+    cy.visitFia('/fia/reduction-history/IMAT/stack-viewer');
+
+    cy.wait('@getImatStacks');
+    cy.location('search').should('include', 'jobId=302').and('include', 'experiment=24680');
+    cy.wait('@findImatStack');
+    cy.wait('@listImatImages');
+    cy.contains('newest-frame.tif').should('be.visible');
+
+    cy.contains('button', 'Experiment 13579').click();
+    cy.contains('button', 'IMAT00000301').click();
+
+    cy.location('search').should('include', 'jobId=301').and('include', 'experiment=13579');
+    cy.wait('@findImatStack');
+    cy.wait('@listImatImages');
+    cy.contains('older-frame.tif').should('be.visible');
   });
 });

--- a/src/components/imat/ImatStackJobTree.test.tsx
+++ b/src/components/imat/ImatStackJobTree.test.tsx
@@ -1,0 +1,148 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ImatStackJobTree from './ImatStackJobTree';
+import { fiaApi } from '../../lib/api';
+
+import type { Job } from '../../lib/types';
+
+vi.mock('../../lib/api', () => ({
+  fiaApi: {
+    get: vi.fn(),
+  },
+}));
+
+const makeJob = (id: number, experimentNumber: number, runStart: string, filename = `IMAT${id}.raw`): Job => ({
+  id,
+  start: runStart,
+  end: runStart,
+  state: 'SUCCESSFUL',
+  status_message: '',
+  runner_image: 'imat:latest',
+  type: 'JobType.REDUCTION',
+  inputs: {},
+  outputs: `/output/run-${id}`,
+  stacktrace: '',
+  script: { value: 'reduce()' },
+  run: {
+    experiment_number: experimentNumber,
+    filename: `/archive/${filename}`,
+    run_start: runStart,
+    run_end: runStart,
+    title: `Sample ${id}`,
+    users: 'User',
+    good_frames: 10,
+    raw_frames: 10,
+    instrument_name: 'IMAT',
+  },
+});
+
+const renderTree = (
+  overrides: Partial<React.ComponentProps<typeof ImatStackJobTree>> = {}
+): ReturnType<typeof render> =>
+  render(
+    <ImatStackJobTree autoSelect={false} selectedJobId={null} selectedJob={null} onSelectJob={vi.fn()} {...overrides} />
+  );
+
+describe('ImatStackJobTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('groups jobs by experiment, sorts newest first, and highlights the selected stack', async () => {
+    const olderJob = makeJob(10, 1234, '2026-01-01T10:00:00Z');
+    const selectedJob = makeJob(11, 1234, '2026-01-02T10:00:00Z');
+    const otherExperiment = makeJob(12, 9999, '2025-12-01T10:00:00Z');
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: [olderJob, selectedJob, otherExperiment] });
+
+    renderTree({ selectedJobId: selectedJob.id, selectedJob });
+
+    const selectedStack = await screen.findByRole('button', { name: /IMAT11/i });
+    expect(selectedStack).toHaveAttribute('aria-current', 'true');
+    expect(screen.getAllByRole('button', { name: /Experiment/i })[0]).toHaveTextContent('Experiment 1234');
+
+    const experimentGroup = screen.getByRole('button', { name: /Experiment 1234/i });
+    const jobButtons = within(document.getElementById('imat-experiment-1234')!).getAllByRole('button');
+    expect(experimentGroup).toHaveAttribute('aria-expanded', 'true');
+    expect(jobButtons[0]).toHaveTextContent('IMAT11');
+    expect(jobButtons[1]).toHaveTextContent('IMAT10');
+  });
+
+  test('automatically selects the newest stack only when no URL selection exists', async () => {
+    const onSelectJob = vi.fn();
+    const newestJob = makeJob(22, 2000, '2026-02-02T10:00:00Z');
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: [newestJob, makeJob(21, 2000, '2026-02-01T10:00:00Z')] });
+
+    renderTree({ autoSelect: true, onSelectJob });
+
+    await waitFor(() => expect(onSelectJob).toHaveBeenCalledWith(newestJob, true));
+  });
+
+  test('queries full history by exact experiment number and filename', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: [] });
+    renderTree();
+    await screen.findByText('No successful IMAT stacks found.');
+
+    await user.type(screen.getByLabelText('Stack search value'), '12345');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      const lastOptions = vi.mocked(fiaApi.get).mock.calls.at(-1)?.[1];
+      expect(lastOptions?.params.filters).toBe(
+        JSON.stringify({ job_state_in: ['SUCCESSFUL'], experiment_number_in: [12345] })
+      );
+    });
+
+    await user.click(screen.getByRole('combobox', { name: 'Search by' }));
+    await user.click(screen.getByRole('option', { name: 'Run/file' }));
+    await user.clear(screen.getByLabelText('Stack search value'));
+    await user.type(screen.getByLabelText('Stack search value'), 'IMAT00042');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      const lastOptions = vi.mocked(fiaApi.get).mock.calls.at(-1)?.[1];
+      expect(lastOptions?.params.filters).toBe(JSON.stringify({ job_state_in: ['SUCCESSFUL'], filename: 'IMAT00042' }));
+    });
+  });
+
+  test('loads another page and removes duplicate jobs', async () => {
+    const user = userEvent.setup();
+    const firstPage = Array.from({ length: 26 }, (_, index) =>
+      makeJob(100 - index, 3000, `2026-01-${String(26 - index).padStart(2, '0')}T10:00:00Z`)
+    );
+    const nextJob = makeJob(200, 4000, '2025-01-01T10:00:00Z');
+    vi.mocked(fiaApi.get)
+      .mockResolvedValueOnce({ data: firstPage })
+      .mockResolvedValueOnce({ data: [firstPage[0], nextJob] });
+
+    renderTree();
+    await user.click(await screen.findByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => {
+      expect(vi.mocked(fiaApi.get).mock.calls[1][1]?.params.offset).toBe(25);
+      expect(screen.getByRole('button', { name: /Experiment 4000/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Experiment 3000/i }));
+    expect(screen.getAllByRole('button', { name: /IMAT100/i })).toHaveLength(1);
+  });
+
+  test('shows a retry action when loading fails', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fiaApi.get).mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce({ data: [] });
+
+    renderTree();
+    expect(await screen.findByText('Unable to load IMAT stacks.')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('No successful IMAT stacks found.')).toBeInTheDocument();
+    expect(fiaApi.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/imat/ImatStackJobTree.tsx
+++ b/src/components/imat/ImatStackJobTree.tsx
@@ -1,0 +1,445 @@
+import ChevronRight from '@mui/icons-material/ChevronRight';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import Folder from '@mui/icons-material/Folder';
+import FolderOpen from '@mui/icons-material/FolderOpen';
+import ImageIcon from '@mui/icons-material/Image';
+import Search from '@mui/icons-material/Search';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Collapse,
+  FormControl,
+  InputLabel,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import axios from 'axios';
+import React from 'react';
+
+import { fiaApi } from '../../lib/api';
+import { formatUtcForLocale } from '../../lib/timezone';
+
+import type { Job, JobQueryFilters } from '../../lib/types';
+
+const PAGE_SIZE = 25;
+const PAGE_REQUEST_SIZE = PAGE_SIZE + 1;
+
+type SearchType = 'experiment' | 'filename';
+
+type ActiveSearch = {
+  type: SearchType;
+  value: string;
+};
+
+type JobGroup = {
+  experimentNumber: number | null;
+  key: string;
+  jobs: Job[];
+  latestRunStart: number;
+};
+
+export type ImatStackJobTreeProps = {
+  autoSelect: boolean;
+  selectedJobId: number | null;
+  selectedJob: Job | null;
+  onSelectJob: (job: Job, replace?: boolean) => void;
+};
+
+const getRunStartTime = (job: Job): number => {
+  const timestamp = Date.parse(job.run?.run_start || job.start || '');
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+const getFilename = (job: Job): string => {
+  const filename = job.run?.filename?.split(/[\\/]/).pop() || '';
+  return filename.replace(/\.[^.]+$/, '') || `Job ${job.id}`;
+};
+
+const isSuccessfulImatJob = (job: Job): boolean =>
+  job.state === 'SUCCESSFUL' && job.run?.instrument_name?.toUpperCase() === 'IMAT';
+
+const groupJobs = (jobs: Job[]): JobGroup[] => {
+  const groups = new Map<string, JobGroup>();
+
+  [...jobs]
+    .filter(isSuccessfulImatJob)
+    .sort((left, right) => getRunStartTime(right) - getRunStartTime(left))
+    .forEach((job) => {
+      const experimentNumber = job.run?.experiment_number ?? null;
+      const key = experimentNumber === null ? 'unknown' : experimentNumber.toString();
+      const existingGroup = groups.get(key);
+
+      if (existingGroup) {
+        existingGroup.jobs.push(job);
+        existingGroup.latestRunStart = Math.max(existingGroup.latestRunStart, getRunStartTime(job));
+      } else {
+        groups.set(key, {
+          experimentNumber,
+          key,
+          jobs: [job],
+          latestRunStart: getRunStartTime(job),
+        });
+      }
+    });
+
+  return Array.from(groups.values()).sort((left, right) => right.latestRunStart - left.latestRunStart);
+};
+
+const getFilters = (activeSearch: ActiveSearch | null): JobQueryFilters => {
+  const filters: JobQueryFilters = { job_state_in: ['SUCCESSFUL'] };
+
+  if (activeSearch?.type === 'experiment') {
+    filters.experiment_number_in = [Number(activeSearch.value)];
+  } else if (activeSearch?.type === 'filename') {
+    filters.filename = activeSearch.value;
+  }
+
+  return filters;
+};
+
+const mergeUniqueJobs = (currentJobs: Job[], nextJobs: Job[]): Job[] => {
+  const jobsById = new Map(currentJobs.map((job) => [job.id, job]));
+  nextJobs.forEach((job) => jobsById.set(job.id, job));
+  return Array.from(jobsById.values()).sort((left, right) => getRunStartTime(right) - getRunStartTime(left));
+};
+
+const ImatStackJobTree: React.FC<ImatStackJobTreeProps> = ({ autoSelect, selectedJobId, selectedJob, onSelectJob }) => {
+  const [jobs, setJobs] = React.useState<Job[]>([]);
+  const [offset, setOffset] = React.useState(0);
+  const [hasMore, setHasMore] = React.useState(false);
+  const [loading, setLoading] = React.useState(true);
+  const [loadingMore, setLoadingMore] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [retryKey, setRetryKey] = React.useState(0);
+  const [searchType, setSearchType] = React.useState<SearchType>('experiment');
+  const [searchValue, setSearchValue] = React.useState('');
+  const [searchError, setSearchError] = React.useState<string | null>(null);
+  const [activeSearch, setActiveSearch] = React.useState<ActiveSearch | null>(null);
+  const [expandedExperiments, setExpandedExperiments] = React.useState<Set<string>>(new Set());
+  const loadMoreControllerRef = React.useRef<AbortController | null>(null);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    loadMoreControllerRef.current?.abort();
+
+    const fetchFirstPage = async (): Promise<void> => {
+      setLoading(true);
+      setError(null);
+      setJobs([]);
+      setOffset(0);
+      setHasMore(false);
+
+      try {
+        const response = await fiaApi.get<Job[]>('/instrument/IMAT/jobs', {
+          signal: controller.signal,
+          params: {
+            limit: PAGE_REQUEST_SIZE,
+            offset: 0,
+            order_by: 'run_start',
+            order_direction: 'desc',
+            include_run: true,
+            filters: JSON.stringify(getFilters(activeSearch)),
+          },
+        });
+        if (controller.signal.aborted) return;
+        const visibleJobs = response.data.filter(isSuccessfulImatJob).slice(0, PAGE_SIZE);
+        setJobs(visibleJobs);
+        setOffset(visibleJobs.length);
+        setHasMore(response.data.length > PAGE_SIZE);
+      } catch (err: unknown) {
+        if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
+        setError('Unable to load IMAT stacks.');
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+
+    void fetchFirstPage();
+    return () => controller.abort();
+  }, [activeSearch, retryKey]);
+
+  React.useEffect(() => {
+    if (autoSelect && !loading && selectedJobId === null && jobs.length > 0) {
+      onSelectJob(jobs[0], true);
+    }
+  }, [autoSelect, jobs, loading, onSelectJob, selectedJobId]);
+
+  React.useEffect(() => {
+    if (!selectedJob) return;
+    const experimentKey = selectedJob.run?.experiment_number?.toString() ?? 'unknown';
+    setExpandedExperiments((current) => {
+      if (current.has(experimentKey)) return current;
+      const next = new Set(current);
+      next.add(experimentKey);
+      return next;
+    });
+  }, [selectedJob]);
+
+  React.useEffect(
+    () => () => {
+      loadMoreControllerRef.current?.abort();
+    },
+    []
+  );
+
+  const displayedJobs = React.useMemo(() => {
+    if (!selectedJob || jobs.some((job) => job.id === selectedJob.id)) return jobs;
+    return mergeUniqueJobs(jobs, [selectedJob]);
+  }, [jobs, selectedJob]);
+
+  const jobGroups = React.useMemo(() => groupJobs(displayedJobs), [displayedJobs]);
+
+  const handleToggleExperiment = (experimentKey: string): void => {
+    setExpandedExperiments((current) => {
+      const next = new Set(current);
+      if (next.has(experimentKey)) {
+        next.delete(experimentKey);
+      } else {
+        next.add(experimentKey);
+      }
+      return next;
+    });
+  };
+
+  const handleSearch = (event: React.FormEvent): void => {
+    event.preventDefault();
+    const value = searchValue.trim();
+
+    if (!value) {
+      setSearchError('Enter a search value.');
+      return;
+    }
+
+    const experimentNumber = Number(value);
+    if (
+      searchType === 'experiment' &&
+      (!/^\d+$/.test(value) || !Number.isSafeInteger(experimentNumber) || experimentNumber <= 0)
+    ) {
+      setSearchError('Enter a valid experiment number.');
+      return;
+    }
+
+    setSearchError(null);
+    setActiveSearch({ type: searchType, value });
+  };
+
+  const handleClearSearch = (): void => {
+    setSearchValue('');
+    setSearchError(null);
+    setActiveSearch(null);
+  };
+
+  const handleLoadMore = async (): Promise<void> => {
+    loadMoreControllerRef.current?.abort();
+    const controller = new AbortController();
+    loadMoreControllerRef.current = controller;
+    setLoadingMore(true);
+    setError(null);
+
+    try {
+      const response = await fiaApi.get<Job[]>('/instrument/IMAT/jobs', {
+        signal: controller.signal,
+        params: {
+          limit: PAGE_REQUEST_SIZE,
+          offset,
+          order_by: 'run_start',
+          order_direction: 'desc',
+          include_run: true,
+          filters: JSON.stringify(getFilters(activeSearch)),
+        },
+      });
+      if (controller.signal.aborted) return;
+      const visibleJobs = response.data.filter(isSuccessfulImatJob).slice(0, PAGE_SIZE);
+      setJobs((current) => mergeUniqueJobs(current, visibleJobs));
+      setOffset((current) => current + visibleJobs.length);
+      setHasMore(response.data.length > PAGE_SIZE);
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
+      setError('Unable to load more IMAT stacks.');
+    } finally {
+      if (!controller.signal.aborted) setLoadingMore(false);
+    }
+  };
+
+  return (
+    <Paper
+      component="aside"
+      aria-label="IMAT stack jobs"
+      elevation={0}
+      sx={{
+        width: { xs: '100%', md: 300 },
+        minWidth: { md: 300 },
+        height: { xs: 320, md: 'auto' },
+        maxHeight: { xs: 320, md: 'none' },
+        border: 1,
+        borderColor: 'divider',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <Box component="form" onSubmit={handleSearch} sx={{ p: 1.5, borderBottom: 1, borderColor: 'divider' }}>
+        <Typography variant="subtitle1" component="h2" sx={{ fontWeight: 600, mb: 1 }}>
+          Stacks
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <FormControl size="small" sx={{ minWidth: 112 }}>
+            <InputLabel id="imat-stack-search-type-label">Search by</InputLabel>
+            <Select
+              labelId="imat-stack-search-type-label"
+              value={searchType}
+              label="Search by"
+              onChange={(event) => {
+                setSearchType(event.target.value as SearchType);
+                setSearchError(null);
+              }}
+            >
+              <MenuItem value="experiment">Experiment</MenuItem>
+              <MenuItem value="filename">Run/file</MenuItem>
+            </Select>
+          </FormControl>
+          <TextField
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            size="small"
+            label={searchType === 'experiment' ? 'Number' : 'Name'}
+            error={Boolean(searchError)}
+            inputProps={{ 'aria-label': 'Stack search value' }}
+            sx={{ minWidth: 0, flex: 1 }}
+          />
+        </Box>
+        {searchError && (
+          <Typography variant="caption" color="error" role="alert">
+            {searchError}
+          </Typography>
+        )}
+        <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+          <Button type="submit" size="small" variant="contained" startIcon={<Search />} disabled={loading}>
+            Search
+          </Button>
+          <Button size="small" onClick={handleClearSearch} disabled={loading || (!activeSearch && !searchValue)}>
+            Clear
+          </Button>
+        </Box>
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+            <CircularProgress size={24} aria-label="Loading IMAT stacks" />
+          </Box>
+        ) : error && jobs.length === 0 ? (
+          <Box sx={{ p: 1.5 }}>
+            <Alert
+              severity="error"
+              action={
+                <Button color="inherit" size="small" onClick={() => setRetryKey((current) => current + 1)}>
+                  Retry
+                </Button>
+              }
+            >
+              {error}
+            </Alert>
+          </Box>
+        ) : jobGroups.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+            {activeSearch ? 'No successful IMAT stacks match this search.' : 'No successful IMAT stacks found.'}
+          </Typography>
+        ) : (
+          <List component="nav" aria-label="Successful IMAT stacks" disablePadding>
+            {jobGroups.map((group) => {
+              const isExpanded = expandedExperiments.has(group.key);
+              const groupLabel =
+                group.experimentNumber === null ? 'Unknown experiment' : `Experiment ${group.experimentNumber}`;
+
+              return (
+                <React.Fragment key={group.key}>
+                  <ListItemButton
+                    onClick={() => handleToggleExperiment(group.key)}
+                    aria-expanded={isExpanded}
+                    aria-controls={`imat-experiment-${group.key}`}
+                    sx={{ py: 0.75, px: 1.5 }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 32 }}>
+                      {isExpanded ? <ExpandMore fontSize="small" /> : <ChevronRight fontSize="small" />}
+                    </ListItemIcon>
+                    <ListItemIcon sx={{ minWidth: 32 }}>
+                      {isExpanded ? <FolderOpen fontSize="small" color="primary" /> : <Folder fontSize="small" />}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={groupLabel}
+                      secondary={`${group.jobs.length} ${group.jobs.length === 1 ? 'stack' : 'stacks'}`}
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600, noWrap: true }}
+                    />
+                  </ListItemButton>
+                  <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                    <List id={`imat-experiment-${group.key}`} component="div" disablePadding>
+                      {group.jobs.map((job) => {
+                        const isSelected = job.id === selectedJobId;
+                        const secondaryParts = [formatUtcForLocale(job.run?.run_start), job.run?.title || ''].filter(
+                          Boolean
+                        );
+
+                        return (
+                          <ListItemButton
+                            key={job.id}
+                            selected={isSelected}
+                            aria-current={isSelected ? 'true' : undefined}
+                            onClick={() => onSelectJob(job)}
+                            sx={{ pl: 6.5, pr: 1.5, py: 0.75, alignItems: 'flex-start' }}
+                          >
+                            <ListItemIcon sx={{ minWidth: 30, mt: 0.25 }}>
+                              <ImageIcon fontSize="small" color={isSelected ? 'primary' : 'inherit'} />
+                            </ListItemIcon>
+                            <ListItemText
+                              primary={getFilename(job)}
+                              secondary={secondaryParts.join(' · ') || `Job ${job.id}`}
+                              primaryTypographyProps={{
+                                variant: 'body2',
+                                fontWeight: isSelected ? 600 : 400,
+                                noWrap: true,
+                              }}
+                              secondaryTypographyProps={{
+                                variant: 'caption',
+                                noWrap: true,
+                                title: secondaryParts.join(' · '),
+                              }}
+                            />
+                          </ListItemButton>
+                        );
+                      })}
+                    </List>
+                  </Collapse>
+                </React.Fragment>
+              );
+            })}
+          </List>
+        )}
+      </Box>
+
+      {(hasMore || loadingMore || (error && jobs.length > 0)) && (
+        <Box sx={{ p: 1, borderTop: 1, borderColor: 'divider' }}>
+          {error && jobs.length > 0 && (
+            <Typography variant="caption" color="error" role="alert" sx={{ display: 'block', mb: 0.5 }}>
+              {error}
+            </Typography>
+          )}
+          <Button fullWidth size="small" onClick={() => void handleLoadMore()} disabled={loadingMore || !hasMore}>
+            {loadingMore ? <CircularProgress size={20} aria-label="Loading more IMAT stacks" /> : 'Load more'}
+          </Button>
+        </Box>
+      )}
+    </Paper>
+  );
+};
+
+export default ImatStackJobTree;

--- a/src/pages/IMATViewer.test.tsx
+++ b/src/pages/IMATViewer.test.tsx
@@ -1,0 +1,248 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter, Route, useHistory, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import IMATViewer from './IMATViewer';
+import { fiaApi, h5Api } from '../lib/api';
+
+import type { Job } from '../lib/types';
+
+const treeJob = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('@h5web/lib', () => ({
+  DomainWidget: () => <div data-testid="domain-widget" />,
+  HeatmapVis: () => <div data-testid="heatmap" />,
+  RgbVis: () => <div data-testid="rgb-image" />,
+  ScaleType: { Linear: 'linear' },
+  Toolbar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useSafeDomain: (domain: [number, number]) => [domain],
+}));
+
+vi.mock('../components/imat/ImatStackJobTree', () => ({
+  default: ({
+    autoSelect,
+    selectedJobId,
+    onSelectJob,
+  }: {
+    autoSelect: boolean;
+    selectedJobId: number | null;
+    onSelectJob: (job: Job) => void;
+  }) => (
+    <aside aria-label="Mock stack tree">
+      <span>{`Selected job: ${selectedJobId ?? 'none'}`}</span>
+      <span>{`Auto select: ${autoSelect}`}</span>
+      <button type="button" onClick={() => onSelectJob(treeJob.get() as Job)}>
+        Select another stack
+      </button>
+    </aside>
+  ),
+}));
+
+vi.mock('../lib/api', () => ({
+  fiaApi: { get: vi.fn() },
+  h5Api: { get: vi.fn() },
+}));
+
+const makeJob = (id: number, experimentNumber: number, filename = `IMAT${id}.raw`): Job => ({
+  id,
+  start: '2026-01-01T10:00:00Z',
+  end: '2026-01-01T10:05:00Z',
+  state: 'SUCCESSFUL',
+  status_message: '',
+  runner_image: 'imat:latest',
+  type: 'JobType.REDUCTION',
+  inputs: {},
+  outputs: `/output/run-${id}`,
+  stacktrace: '',
+  script: { value: 'reduce()' },
+  run: {
+    experiment_number: experimentNumber,
+    filename: `/archive/${filename}`,
+    run_start: '2026-01-01T09:00:00Z',
+    run_end: '2026-01-01T09:30:00Z',
+    title: `Sample ${id}`,
+    users: 'User',
+    good_frames: 10,
+    raw_frames: 10,
+    instrument_name: 'IMAT',
+  },
+});
+
+const LocationDisplay = (): React.ReactElement => {
+  const history = useHistory();
+  const location = useLocation();
+  return (
+    <>
+      <output data-testid="location">{`${location.pathname}${location.search}`}</output>
+      <button type="button" onClick={() => history.goBack()}>
+        Back
+      </button>
+    </>
+  );
+};
+
+const renderViewer = (path: string): ReturnType<typeof render> =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Route path="/reduction-history/IMAT/stack-viewer">
+        <IMATViewer mode="stack" showNav={false} />
+        <LocationDisplay />
+      </Route>
+    </MemoryRouter>
+  );
+
+const mockStackResponses = (): void => {
+  vi.mocked(h5Api.get).mockImplementation(async (url) => {
+    if (String(url).startsWith('/find_file/')) return { data: '/data/imat' };
+    if (url === '/imat/list-images') return { data: ['frame-1.tif', 'frame-2.tif'] };
+    if (url === '/imat/image') {
+      return {
+        data: new Uint16Array([1, 2, 3, 4]).buffer,
+        headers: {
+          'x-image-width': '2',
+          'x-image-height': '2',
+          'x-original-width': '2',
+          'x-original-height': '2',
+        },
+      };
+    }
+    throw new Error(`Unexpected H5 request: ${url}`);
+  });
+};
+
+describe('IMATViewer stack selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    treeJob.get.mockReturnValue(makeJob(2, 2222));
+    mockStackResponses();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('hydrates and canonicalises an older deep-linked job, then clamps its image index', async () => {
+    const job = makeJob(1, 1111);
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: job });
+
+    renderViewer(
+      '/reduction-history/IMAT/stack-viewer?jobId=1&experiment=9999&instrument=BAD&imageIndex=99&viewerSize=small'
+    );
+
+    await waitFor(() =>
+      expect(fiaApi.get).toHaveBeenCalledWith('/job/1', expect.objectContaining({ signal: expect.anything() }))
+    );
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('experiment=1111'));
+    expect(screen.getByTestId('location')).toHaveTextContent('instrument=IMAT');
+
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('imageIndex=1'));
+    expect(await screen.findByText('Image 2 of 2')).toBeInTheDocument();
+    expect(await screen.findByTestId('heatmap')).toBeInTheDocument();
+  });
+
+  test('pushes a selected job to the URL, resets the image, and preserves viewer size', async () => {
+    const user = userEvent.setup();
+    renderViewer('/reduction-history/IMAT/stack-viewer?viewerSize=large&imageIndex=4');
+
+    await user.click(screen.getByRole('button', { name: 'Select another stack' }));
+
+    await waitFor(() => {
+      const location = screen.getByTestId('location');
+      expect(location).toHaveTextContent('jobId=2');
+      expect(location).toHaveTextContent('experiment=2222');
+      expect(location).toHaveTextContent('instrument=IMAT');
+      expect(location).toHaveTextContent('viewerSize=large');
+      expect(location).not.toHaveTextContent('imageIndex=');
+    });
+    expect(screen.getByText('Selected job: 2')).toBeInTheDocument();
+  });
+
+  test('ignores stale directory responses when users switch jobs quickly', async () => {
+    const user = userEvent.setup();
+    const firstJob = makeJob(1, 1111);
+    const secondJob = makeJob(2, 2222);
+    let resolveFirstDirectory: ((value: { data: string }) => void) | undefined;
+    const firstDirectoryResponse = new Promise<{ data: string }>((resolve) => {
+      resolveFirstDirectory = resolve;
+    });
+
+    vi.mocked(h5Api.get).mockImplementation(async (url, options) => {
+      const requestUrl = String(url);
+      if (requestUrl.includes('experiment_number/1111')) return firstDirectoryResponse;
+      if (requestUrl.includes('experiment_number/2222')) return { data: '/data/new' };
+      if (url === '/imat/list-images') return { data: ['new-frame.tif'] };
+      if (url === '/imat/image') {
+        return {
+          data: new Uint16Array([1, 2, 3, 4]).buffer,
+          headers: {
+            'x-image-width': '2',
+            'x-image-height': '2',
+            'x-original-width': '2',
+            'x-original-height': '2',
+          },
+        };
+      }
+      throw new Error(`Unexpected H5 request: ${url} ${JSON.stringify(options)}`);
+    });
+
+    treeJob.get.mockReturnValue(firstJob);
+    renderViewer('/reduction-history/IMAT/stack-viewer');
+    await user.click(screen.getByRole('button', { name: 'Select another stack' }));
+    await waitFor(() =>
+      expect(h5Api.get).toHaveBeenCalledWith(
+        expect.stringContaining('experiment_number/1111'),
+        expect.objectContaining({ signal: expect.anything() })
+      )
+    );
+
+    treeJob.get.mockReturnValue(secondJob);
+    await user.click(screen.getByRole('button', { name: 'Select another stack' }));
+    expect(await screen.findByText('new-frame.tif')).toBeInTheDocument();
+
+    resolveFirstDirectory?.({ data: '/data/old' });
+    await waitFor(() => {
+      const listedPaths = vi
+        .mocked(h5Api.get)
+        .mock.calls.filter(([url]) => url === '/imat/list-images')
+        .map(([, options]) => options?.params.path);
+      expect(listedPaths).toEqual(['/data/new/run-2']);
+    });
+  });
+
+  test('rehydrates the URL-selected job when navigating back', async () => {
+    const user = userEvent.setup();
+    const firstJob = makeJob(1, 1111);
+    const secondJob = makeJob(2, 2222);
+    vi.mocked(fiaApi.get).mockImplementation(async (url) => ({
+      data: String(url) === '/job/1' ? firstJob : secondJob,
+    }));
+    treeJob.get.mockReturnValue(secondJob);
+
+    renderViewer('/reduction-history/IMAT/stack-viewer?jobId=1&experiment=1111&instrument=IMAT');
+    expect(await screen.findByText('Selected job: 1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Select another stack' }));
+    expect(await screen.findByText('Selected job: 2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(await screen.findByText('Selected job: 1')).toBeInTheDocument();
+    await waitFor(() => {
+      const firstJobRequests = vi.mocked(fiaApi.get).mock.calls.filter(([url]) => url === '/job/1');
+      expect(firstJobRequests).toHaveLength(2);
+    });
+  });
+
+  test('rejects a deep link to a non-IMAT or unsuccessful job without loading stack data', async () => {
+    const unavailableJob = makeJob(3, 3333);
+    unavailableJob.state = 'ERROR';
+    vi.mocked(fiaApi.get).mockResolvedValue({ data: unavailableJob });
+
+    renderViewer('/reduction-history/IMAT/stack-viewer?jobId=3');
+
+    expect(await screen.findByText('This job is not an available successful IMAT stack.')).toBeInTheDocument();
+    expect(h5Api.get).not.toHaveBeenCalled();
+    expect(screen.getByText('Auto select: false')).toBeInTheDocument();
+  });
+});

--- a/src/pages/IMATViewer.tsx
+++ b/src/pages/IMATViewer.tsx
@@ -1,6 +1,7 @@
 import '@h5web/lib/styles.css';
 import { DomainWidget, HeatmapVis, RgbVis, ScaleType, Toolbar, useSafeDomain } from '@h5web/lib';
 import {
+  Alert,
   Box,
   CircularProgress,
   Paper,
@@ -16,10 +17,12 @@ import ndarray from 'ndarray';
 import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import ImatStackJobTree from '../components/imat/ImatStackJobTree';
 import NavArrows from '../components/navigation/NavArrows';
 import { fiaApi, h5Api } from '../lib/api';
-import { Job } from '../lib/types';
+import { parseJobOutputs } from '../lib/hooks';
 
+import type { Job } from '../lib/types';
 import type { CustomDomain, Domain } from '@h5web/lib';
 
 type ImatImagePayload = {
@@ -54,13 +57,26 @@ const STACK_INTENSITY_DOMAIN: Domain = [0, 65535];
 const isViewerSize = (value: string | null): value is ViewerSize =>
   value !== null && VIEWER_SIZES.includes(value as ViewerSize);
 
+const getJobId = (value: string | null): number | null => {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const jobId = Number(value);
+  return Number.isSafeInteger(jobId) && jobId > 0 ? jobId : null;
+};
+
+const getImageIndex = (value: string | null): number => {
+  const index = Number(value);
+  return Number.isSafeInteger(index) && index >= 0 ? index : 0;
+};
+
+const isSuccessfulImatJob = (job: Job): boolean =>
+  job.state === 'SUCCESSFUL' && job.run?.instrument_name?.toUpperCase() === 'IMAT';
+
 const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
   const theme = useTheme();
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
-  const initialJobId = queryParams.get('jobId');
-  const initialInstrument = queryParams.get('instrument');
-  const initialExperiment = queryParams.get('experiment');
+  const rawStackJobId = queryParams.get('jobId');
+  const stackJobId = getJobId(rawStackJobId);
 
   // Latest Image state
   const [latestDataset, setLatestDataset] = React.useState<LatestImatImageDataset | null>(null);
@@ -68,12 +84,15 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
   const [latestError, setLatestError] = React.useState<string | null>(null);
 
   const history = useHistory();
-  const initialImageIndex = parseInt(queryParams.get('imageIndex') || '0', 10);
+  const initialImageIndex = getImageIndex(queryParams.get('imageIndex'));
   const viewerSizeParam = queryParams.get('viewerSize');
   const initialViewerSize = isViewerSize(viewerSizeParam) ? viewerSizeParam : 'fit';
 
   // Stack Viewer state
-  const [stackJobId] = React.useState<string | null>(initialJobId);
+  const [selectedJob, setSelectedJob] = React.useState<Job | null>(null);
+  const selectedJobRef = React.useRef<Job | null>(null);
+  const [selectedJobLoading, setSelectedJobLoading] = React.useState(false);
+  const [selectedJobError, setSelectedJobError] = React.useState<string | null>(null);
   const [stackImages, setStackImages] = React.useState<string[]>([]);
   const [currentImageIndex, setCurrentImageIndex] = React.useState(initialImageIndex);
   const [stackDataset, setStackDataset] = React.useState<StackImatImageDataset | null>(null);
@@ -81,8 +100,11 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
   const [stackError, setStackError] = React.useState<string | null>(null);
   const [directoryPath, setDirectoryPath] = React.useState<string | null>(null);
   const [isSliding, setIsSliding] = React.useState(false);
-  const [viewerSize, setViewerSize] = React.useState<'fit' | 'small' | 'medium' | 'large' | 'full'>(initialViewerSize);
+  const [viewerSize, setViewerSize] = React.useState<ViewerSize>(initialViewerSize);
   const [stackCustomIntensityDomain, setStackCustomIntensityDomain] = React.useState<CustomDomain>([null, null]);
+  const locationSearchRef = React.useRef(location.search);
+  locationSearchRef.current = location.search;
+  selectedJobRef.current = selectedJob;
 
   const stackIntensityDomain = React.useMemo<Domain>(
     () => [
@@ -93,36 +115,115 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
   );
   const [safeStackIntensityDomain] = useSafeDomain(stackIntensityDomain, STACK_INTENSITY_DOMAIN, ScaleType.Linear);
 
-  // Sync state to URL
+  const writeSelectedJobToUrl = React.useCallback(
+    (job: Job, replace: boolean, resetImageIndex: boolean): void => {
+      const params = new URLSearchParams(history.location.search);
+      params.set('jobId', job.id.toString());
+      params.set('experiment', job.run.experiment_number.toString());
+      params.set('instrument', 'IMAT');
+      if (resetImageIndex) params.delete('imageIndex');
+
+      const search = params.toString();
+      const nextLocation = {
+        pathname: history.location.pathname,
+        search: search ? `?${search}` : '',
+      };
+
+      if (nextLocation.search === history.location.search) return;
+      if (replace) {
+        history.replace(nextLocation);
+      } else {
+        history.push(nextLocation);
+      }
+    },
+    [history]
+  );
+
+  const handleSelectJob = React.useCallback(
+    (job: Job, replace = false): void => {
+      setSelectedJob(job);
+      setSelectedJobError(null);
+      setCurrentImageIndex(0);
+      writeSelectedJobToUrl(job, replace, true);
+    },
+    [writeSelectedJobToUrl]
+  );
+
+  // Hydrate deep-linked jobs and browser history selections that are not already in memory.
+  React.useEffect(() => {
+    if (mode !== 'stack') return;
+
+    if (rawStackJobId !== null && stackJobId === null) {
+      setSelectedJob(null);
+      setSelectedJobLoading(false);
+      setSelectedJobError('The selected stack job ID is invalid.');
+      return;
+    }
+
+    if (stackJobId === null) {
+      setSelectedJob(null);
+      setSelectedJobLoading(false);
+      setSelectedJobError(null);
+      return;
+    }
+
+    if (selectedJobRef.current?.id === stackJobId) {
+      setSelectedJobLoading(false);
+      setSelectedJobError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setSelectedJob(null);
+    setSelectedJobLoading(true);
+    setSelectedJobError(null);
+
+    const fetchSelectedJob = async (): Promise<void> => {
+      try {
+        const response = await fiaApi.get<Job>(`/job/${stackJobId}`, { signal: controller.signal });
+        if (controller.signal.aborted) return;
+        if (!isSuccessfulImatJob(response.data)) {
+          setSelectedJobError('This job is not an available successful IMAT stack.');
+          return;
+        }
+
+        setSelectedJob(response.data);
+        writeSelectedJobToUrl(response.data, true, false);
+      } catch (err: unknown) {
+        if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
+        setSelectedJobError('The selected IMAT stack could not be loaded.');
+      } finally {
+        if (!controller.signal.aborted) setSelectedJobLoading(false);
+      }
+    };
+
+    void fetchSelectedJob();
+    return () => controller.abort();
+  }, [mode, rawStackJobId, stackJobId, writeSelectedJobToUrl]);
+
+  // Keep viewer controls in sync with browser navigation.
   React.useEffect(() => {
     if (mode !== 'stack') return;
     const params = new URLSearchParams(location.search);
-    let changed = false;
+    const nextImageIndex = getImageIndex(params.get('imageIndex'));
+    const nextViewerSize = isViewerSize(params.get('viewerSize')) ? (params.get('viewerSize') as ViewerSize) : 'fit';
+    setCurrentImageIndex((current) => (current === nextImageIndex ? current : nextImageIndex));
+    setViewerSize((current) => (current === nextViewerSize ? current : nextViewerSize));
+  }, [location.search, mode]);
 
-    if (currentImageIndex !== 0) {
-      if (params.get('imageIndex') !== currentImageIndex.toString()) {
-        params.set('imageIndex', currentImageIndex.toString());
-        changed = true;
+  const replaceViewerQueryParam = React.useCallback(
+    (name: 'imageIndex' | 'viewerSize', value: string, defaultValue: string): void => {
+      const params = new URLSearchParams(locationSearchRef.current);
+      if (value === defaultValue) {
+        params.delete(name);
+      } else {
+        params.set(name, value);
       }
-    } else if (params.has('imageIndex')) {
-      params.delete('imageIndex');
-      changed = true;
-    }
-
-    if (viewerSize !== 'fit') {
-      if (params.get('viewerSize') !== viewerSize) {
-        params.set('viewerSize', viewerSize);
-        changed = true;
-      }
-    } else if (params.has('viewerSize')) {
-      params.delete('viewerSize');
-      changed = true;
-    }
-
-    if (changed) {
-      history.replace({ search: params.toString() });
-    }
-  }, [mode, currentImageIndex, viewerSize, history, location.search]);
+      const search = params.toString();
+      history.replace({ pathname: history.location.pathname, search: search ? `?${search}` : '' });
+    },
+    [history]
+  );
 
   // Memoized arrays for visualization
   const latestArray = React.useMemo(() => {
@@ -189,50 +290,55 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
     };
   }, [mode]);
 
-  // Resolve directory path for stack
+  // Reset all stack-specific state as soon as the selected URL job changes.
   React.useEffect(() => {
-    if (mode !== 'stack' || !stackJobId || !initialInstrument || !initialExperiment) return;
+    if (mode !== 'stack') return;
+    setStackImages([]);
+    setStackDataset(null);
+    setDirectoryPath(null);
+    setStackError(null);
+    setIsSliding(false);
+    setStackCustomIntensityDomain([null, null]);
+  }, [mode, stackJobId]);
+
+  // Resolve the selected job's output directory from authoritative job metadata.
+  React.useEffect(() => {
+    if (mode !== 'stack' || !selectedJob) return;
+    const controller = new AbortController();
+    const experimentNumber = selectedJob.run.experiment_number;
+    const instrumentName = selectedJob.run.instrument_name;
 
     const resolvePath = async (): Promise<void> => {
       try {
         setStackLoading(true);
         setStackError(null);
 
-        // Fetch job data to get the run number (from filename)
-        if (!initialInstrument || !initialExperiment) {
-          throw new Error('Missing instrument or experiment number');
-        }
-        const jobResponse = await fiaApi.get<Job>(`/job/${stackJobId}`);
-        const job = jobResponse.data;
-        const filename = job.run?.filename || '';
-        const runNumberMatch = filename.match(/\d+/);
-        const runNumber = runNumberMatch ? parseInt(runNumberMatch[0], 10).toString() : '';
+        const filename = selectedJob.run?.filename?.split(/[\\/]/).pop() || '';
+        const runNumberMatches = filename.match(/\d+/g);
+        const runNumberMatch = runNumberMatches?.[runNumberMatches.length - 1];
+        const runNumber = runNumberMatch ? parseInt(runNumberMatch, 10).toString() : '';
 
         // Try to resolve path via find_file
         try {
           const response = await h5Api.get<string>(
-            `/find_file/instrument/${initialInstrument}/experiment_number/${initialExperiment}`,
+            `/find_file/instrument/${instrumentName}/experiment_number/${experimentNumber}`,
             {
               params: { filename: '.' },
+              signal: controller.signal,
             }
           );
+          if (controller.signal.aborted) return;
           let path = response.data;
           if (runNumber) path = `${path}/run-${runNumber}`;
           setDirectoryPath(path);
-        } catch (err) {
+        } catch (err: unknown) {
+          if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
           console.warn('find_file failed, falling back to job outputs:', err);
-          let path = job.outputs;
-          if (path && path.startsWith('[')) {
-            try {
-              const outputs = JSON.parse(path);
-              path = Array.isArray(outputs) ? outputs[0] : path;
-            } catch {
-              /* ignore */
-            }
-          }
+          let path = parseJobOutputs(selectedJob.outputs)[0] || selectedJob.outputs;
           if (path) {
             if (path.toLowerCase().endsWith('.tif') || path.toLowerCase().endsWith('.tiff')) {
-              path = path.substring(0, path.lastIndexOf('/'));
+              const lastSeparator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+              path = lastSeparator >= 0 ? path.substring(0, lastSeparator) : path;
             }
             if (runNumber && !path.includes(`run-${runNumber}`)) {
               path = `${path}/run-${runNumber}`;
@@ -242,48 +348,62 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
             setStackError('Failed to resolve output directory');
           }
         }
-      } catch {
+      } catch (err: unknown) {
+        if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
         setStackError('Failed to resolve output directory');
       } finally {
-        setStackLoading(false);
+        if (!controller.signal.aborted) setStackLoading(false);
       }
     };
-    resolvePath();
-  }, [mode, stackJobId, initialInstrument, initialExperiment]);
+    void resolvePath();
+    return () => controller.abort();
+  }, [mode, selectedJob]);
 
   // Fetch stack image list
   React.useEffect(() => {
     if (mode !== 'stack' || !directoryPath) return;
+    const controller = new AbortController();
 
     const fetchList = async (): Promise<void> => {
       try {
+        setStackLoading(true);
+        setStackError(null);
         const response = await h5Api.get<string[]>('/imat/list-images', {
           params: { path: directoryPath },
+          signal: controller.signal,
         });
-        const sortedData = response.data.sort(
+        if (controller.signal.aborted) return;
+        const sortedData = [...response.data].sort(
           new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare
         );
         setStackImages(sortedData);
-      } catch {
+      } catch (err: unknown) {
+        if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
         setStackError('Failed to list images in stack');
+      } finally {
+        if (!controller.signal.aborted) setStackLoading(false);
       }
     };
-    fetchList();
+    void fetchList();
+    return () => controller.abort();
   }, [mode, directoryPath]);
 
   // Fetch individual stack image
   const fetchStackImage = React.useCallback(
-    async (index: number, downsample: number = 1): Promise<void> => {
+    async (index: number, downsample: number, signal: AbortSignal): Promise<void> => {
       if (!directoryPath || !stackImages[index]) return;
       try {
         setStackLoading(true);
+        setStackError(null);
         const response = await h5Api.get<ArrayBuffer>('/imat/image', {
           responseType: 'arraybuffer',
+          signal,
           params: {
             path: `${directoryPath}/${stackImages[index]}`,
             downsample_factor: downsample,
           },
         });
+        if (signal.aborted) return;
 
         // Extract metadata from headers
         const headers = response.headers;
@@ -306,43 +426,63 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
           sampledWidth,
           sampledHeight,
         });
-      } catch {
+      } catch (err: unknown) {
+        if (axios.isAxiosError(err) && err.code === 'ERR_CANCELED') return;
         setStackError('Failed to load stack image');
       } finally {
-        setStackLoading(false);
+        if (!signal.aborted) setStackLoading(false);
       }
     },
     [directoryPath, stackImages]
   );
 
+  React.useEffect(() => {
+    if (mode !== 'stack' || stackImages.length === 0 || currentImageIndex < stackImages.length) return;
+    const clampedIndex = stackImages.length - 1;
+    setCurrentImageIndex(clampedIndex);
+    replaceViewerQueryParam('imageIndex', clampedIndex.toString(), '0');
+  }, [currentImageIndex, mode, replaceViewerQueryParam, stackImages.length]);
+
   // Consolidated image fetching with debounce
   React.useEffect(() => {
     if (mode !== 'stack' || stackImages.length === 0) return;
+    const controller = new AbortController();
 
     const delay = isSliding ? 50 : 250;
     const downsample = isSliding ? 8 : 1;
 
     const timer = setTimeout(() => {
-      fetchStackImage(currentImageIndex, downsample);
+      void fetchStackImage(currentImageIndex, downsample, controller.signal);
     }, delay);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
   }, [mode, stackImages, currentImageIndex, isSliding, fetchStackImage]);
 
   const handleSliderChange = (_event: React.SyntheticEvent | Event, newValue: number | number[]): void => {
     setIsSliding(true);
     const index = newValue as number;
     setCurrentImageIndex(index);
+    replaceViewerQueryParam('imageIndex', index.toString(), '0');
   };
 
   const handleSliderChangeCommitted = (_event: React.SyntheticEvent | Event, newValue: number | number[]): void => {
     setIsSliding(false);
     const index = newValue as number;
     setCurrentImageIndex(index);
+    replaceViewerQueryParam('imageIndex', index.toString(), '0');
+  };
+
+  const handleViewerSizeChange = (_event: React.MouseEvent<HTMLElement>, value: ViewerSize | null): void => {
+    if (!value) return;
+    setViewerSize(value);
+    replaceViewerQueryParam('viewerSize', value, 'fit');
   };
 
   const stackDomainWidgetStyles = {
-    width: { xs: '100%', sm: 500 },
+    width: '100%',
     maxWidth: '100%',
     display: 'flex',
     alignItems: 'center',
@@ -414,7 +554,7 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
   return (
     <>
       {showNav && <NavArrows />}
-      <Box sx={{ p: 2, height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ px: '20px', pb: 2, height: '100%', display: 'flex', flexDirection: 'column' }}>
         {mode === 'latest' && (
           <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
             {latestLoading && !latestDataset ? (
@@ -463,179 +603,221 @@ const IMATViewer: React.FC<IMATViewerProps> = ({ mode, showNav = true }) => {
         )}
 
         {mode === 'stack' && (
-          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, minHeight: 0 }}>
-            {!stackJobId ? (
-              <Typography sx={{ p: 4, textAlign: 'center' }}>
-                Select a completed job from the Reduction history view to view its image stack.
-              </Typography>
-            ) : (
-              <>
-                <Paper sx={{ p: 2 }}>
-                  <Slider
-                    disabled={stackImages.length === 0}
-                    value={currentImageIndex}
-                    min={0}
-                    max={Math.max(0, stackImages.length - 1)}
-                    onChange={handleSliderChange}
-                    onChangeCommitted={handleSliderChangeCommitted}
-                    valueLabelDisplay="auto"
-                    valueLabelFormat={(v: number) => `Index: ${v}`}
-                  />
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: { xs: 'column', md: 'row' },
+              gap: 2,
+              minHeight: 0,
+            }}
+          >
+            <ImatStackJobTree
+              autoSelect={rawStackJobId === null}
+              selectedJobId={stackJobId}
+              selectedJob={selectedJob}
+              onSelectJob={handleSelectJob}
+            />
+
+            <Box sx={{ flex: 1, minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {selectedJobError ? (
+                <Alert severity="error">{selectedJobError}</Alert>
+              ) : selectedJobLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 8 }}>
+                  <CircularProgress aria-label="Loading selected IMAT stack" />
+                </Box>
+              ) : !selectedJob ? (
+                <Typography sx={{ p: 4, textAlign: 'center' }}>Select a job to view its image stack.</Typography>
+              ) : (
+                <>
+                  <Paper sx={{ p: 2 }}>
+                    <Slider
+                      disabled={stackImages.length === 0}
+                      value={currentImageIndex}
+                      min={0}
+                      max={Math.max(0, stackImages.length - 1)}
+                      onChange={handleSliderChange}
+                      onChangeCommitted={handleSliderChangeCommitted}
+                      valueLabelDisplay="auto"
+                      valueLabelFormat={(v: number) => `Index: ${v}`}
+                    />
+
+                    <Box
+                      sx={{
+                        display: 'grid',
+                        gridTemplateColumns: {
+                          xs: 'minmax(0, 1fr)',
+                          md: 'minmax(0, 1fr) auto',
+                          xl: 'minmax(0, 1fr) auto minmax(0, 1fr)',
+                        },
+                        gridTemplateAreas: {
+                          xs: '"image" "size" "intensity"',
+                          md: '"image size" "intensity intensity"',
+                          xl: '"image size intensity"',
+                        },
+                        alignItems: 'center',
+                        gap: 2,
+                        mt: 2,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 2,
+                          flexWrap: 'wrap',
+                          minWidth: 0,
+                          gridArea: 'image',
+                        }}
+                      >
+                        <Typography variant="body2" sx={{ flexShrink: 0 }}>
+                          Image {currentImageIndex + 1} of {stackImages.length}
+                        </Typography>
+
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            color: 'text.secondary',
+                            minWidth: 0,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {stackImages[currentImageIndex]}
+                        </Typography>
+                      </Box>
+
+                      <ToggleButtonGroup
+                        value={viewerSize}
+                        exclusive
+                        onChange={handleViewerSizeChange}
+                        size="small"
+                        aria-label="viewer size"
+                        sx={{
+                          gridArea: 'size',
+                          justifySelf: { xs: 'stretch', sm: 'start', md: 'end', xl: 'center' },
+                          width: { xs: '100%', sm: 'auto' },
+                          maxWidth: '100%',
+                          '& .MuiToggleButton-root': {
+                            width: { xs: 'auto', sm: 76 },
+                            flex: { xs: 1, sm: '0 0 auto' },
+                            px: 0,
+                          },
+                        }}
+                      >
+                        <ToggleButton value="fit" aria-label="fit">
+                          Fit
+                        </ToggleButton>
+                        <ToggleButton value="small" aria-label="small">
+                          Small
+                        </ToggleButton>
+                        <ToggleButton value="medium" aria-label="medium">
+                          Medium
+                        </ToggleButton>
+                        <ToggleButton value="large" aria-label="large">
+                          Large
+                        </ToggleButton>
+                        <ToggleButton value="full" aria-label="full">
+                          Full
+                        </ToggleButton>
+                      </ToggleButtonGroup>
+
+                      <Box
+                        sx={{
+                          gridArea: 'intensity',
+                          justifySelf: { xs: 'stretch', md: 'end' },
+                          width: '100%',
+                          maxWidth: 500,
+                        }}
+                      >
+                        <Box sx={stackDomainWidgetStyles}>
+                          <Typography variant="body2" sx={{ fontWeight: 500, flexShrink: 0 }}>
+                            Colourbar intensity
+                          </Typography>
+                          <Toolbar>
+                            <DomainWidget
+                              dataDomain={STACK_INTENSITY_DOMAIN}
+                              customDomain={stackCustomIntensityDomain}
+                              scaleType={ScaleType.Linear}
+                              disabled={!stackDataset}
+                              onCustomDomainChange={setStackCustomIntensityDomain}
+                            />
+                          </Toolbar>
+                        </Box>
+                      </Box>
+                    </Box>
+                  </Paper>
 
                   <Box
                     sx={{
-                      display: 'grid',
-                      gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1fr) auto minmax(0, 1fr)' },
-                      alignItems: 'center',
-                      gap: 2,
-                      mt: 2,
+                      display: 'flex',
+                      justifyContent: 'center',
+                      overflow: viewerSize === 'fit' ? 'hidden' : 'auto',
+                      flex: 1,
+                      minHeight: 0,
                     }}
                   >
                     <Box
                       sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 2,
-                        flexWrap: 'wrap',
-                        minWidth: 0,
-                      }}
-                    >
-                      <Typography variant="body2" sx={{ flexShrink: 0 }}>
-                        Image {currentImageIndex + 1} of {stackImages.length}
-                      </Typography>
-
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          color: 'text.secondary',
-                          minWidth: 0,
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {stackImages[currentImageIndex]}
-                      </Typography>
-                    </Box>
-
-                    <ToggleButtonGroup
-                      value={viewerSize}
-                      exclusive
-                      onChange={(_e, val) => val && setViewerSize(val)}
-                      size="small"
-                      aria-label="viewer size"
-                      sx={{
-                        justifySelf: { xs: 'start', lg: 'center' },
-                        '& .MuiToggleButton-root': {
-                          width: 76,
-                          px: 0,
-                        },
-                      }}
-                    >
-                      <ToggleButton value="fit" aria-label="fit">
-                        Fit
-                      </ToggleButton>
-                      <ToggleButton value="small" aria-label="small">
-                        Small
-                      </ToggleButton>
-                      <ToggleButton value="medium" aria-label="medium">
-                        Medium
-                      </ToggleButton>
-                      <ToggleButton value="large" aria-label="large">
-                        Large
-                      </ToggleButton>
-                      <ToggleButton value="full" aria-label="full">
-                        Full
-                      </ToggleButton>
-                    </ToggleButtonGroup>
-
-                    <Box sx={{ justifySelf: { xs: 'stretch', lg: 'end' }, width: { xs: '100%', sm: 'auto' } }}>
-                      <Box sx={stackDomainWidgetStyles}>
-                        <Typography variant="body2" sx={{ fontWeight: 500, flexShrink: 0 }}>
-                          Colourbar intensity
-                        </Typography>
-                        <Toolbar>
-                          <DomainWidget
-                            dataDomain={STACK_INTENSITY_DOMAIN}
-                            customDomain={stackCustomIntensityDomain}
-                            scaleType={ScaleType.Linear}
-                            disabled={!stackDataset}
-                            onCustomDomainChange={setStackCustomIntensityDomain}
-                          />
-                        </Toolbar>
-                      </Box>
-                    </Box>
-                  </Box>
-                </Paper>
-
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    overflow: viewerSize === 'fit' ? 'hidden' : 'auto',
-                    flex: 1,
-                    minHeight: 0,
-                  }}
-                >
-                  <Box
-                    sx={{
-                      width:
-                        viewerSize === 'fit'
-                          ? '100%'
-                          : viewerSize === 'small'
-                            ? stackDisplayWidth > 0
-                              ? stackDisplayWidth * 0.25
-                              : '100%'
-                            : viewerSize === 'medium'
+                        width:
+                          viewerSize === 'fit'
+                            ? '100%'
+                            : viewerSize === 'small'
                               ? stackDisplayWidth > 0
-                                ? stackDisplayWidth * 0.5
+                                ? stackDisplayWidth * 0.25
                                 : '100%'
-                              : viewerSize === 'large'
+                              : viewerSize === 'medium'
                                 ? stackDisplayWidth > 0
-                                  ? stackDisplayWidth * 0.75
+                                  ? stackDisplayWidth * 0.5
                                   : '100%'
-                                : stackDisplayWidth || '100%',
-                      aspectRatio: stackAspectRatio,
-                      maxHeight: viewerSize === 'fit' ? 'calc(100vh - 350px)' : 'none',
-                      position: 'relative',
-                      border: '1px solid #ccc',
-                      borderRadius: 1,
-                      overflow: 'hidden',
-                      backgroundColor: 'black',
-                      color: 'rgba(255, 255, 255, 0.92)',
-                      '--h5w-colorBar-bounds--color': 'rgba(255, 255, 255, 0.92)',
-                      '--h5w-colorBar-tickLabels--color': 'rgba(255, 255, 255, 0.86)',
-                      '--h5w-colorBar-ticks--color': 'rgba(255, 255, 255, 0.72)',
-                      mx: 'auto',
-                      flexShrink: 0,
-                    }}
-                  >
-                    {stackDataset ? (
-                      <HeatmapVis
-                        dataArray={stackArray!}
-                        aspect="equal"
-                        flipYAxis
-                        style={{ height: '100%', width: '100%' }}
-                        domain={safeStackIntensityDomain}
-                      />
-                    ) : stackLoading ? (
-                      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                        <CircularProgress />
-                      </Box>
-                    ) : (
-                      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                        <Typography color="white">
-                          {stackError ??
-                            (stackImages.length === 0
-                              ? 'No images found in this job stack.'
-                              : 'Loading stack images...')}
-                        </Typography>
-                      </Box>
-                    )}
+                                : viewerSize === 'large'
+                                  ? stackDisplayWidth > 0
+                                    ? stackDisplayWidth * 0.75
+                                    : '100%'
+                                  : stackDisplayWidth || '100%',
+                        aspectRatio: stackAspectRatio,
+                        maxHeight: viewerSize === 'fit' ? 'calc(100vh - 350px)' : 'none',
+                        position: 'relative',
+                        border: '1px solid #ccc',
+                        borderRadius: 1,
+                        overflow: 'hidden',
+                        backgroundColor: 'black',
+                        color: 'rgba(255, 255, 255, 0.92)',
+                        '--h5w-colorBar-bounds--color': 'rgba(255, 255, 255, 0.92)',
+                        '--h5w-colorBar-tickLabels--color': 'rgba(255, 255, 255, 0.86)',
+                        '--h5w-colorBar-ticks--color': 'rgba(255, 255, 255, 0.72)',
+                        mx: 'auto',
+                        flexShrink: 0,
+                      }}
+                    >
+                      {stackDataset ? (
+                        <HeatmapVis
+                          dataArray={stackArray!}
+                          aspect="equal"
+                          flipYAxis
+                          style={{ height: '100%', width: '100%' }}
+                          domain={safeStackIntensityDomain}
+                        />
+                      ) : stackLoading ? (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+                          <CircularProgress />
+                        </Box>
+                      ) : (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+                          <Typography color="white">
+                            {stackError ??
+                              (stackImages.length === 0
+                                ? 'No images found in this job stack.'
+                                : 'Loading stack images...')}
+                          </Typography>
+                        </Box>
+                      )}
+                    </Box>
                   </Box>
-                </Box>
-              </>
-            )}
+                </>
+              )}
+            </Box>
           </Box>
         )}
       </Box>

--- a/src/pages/Jobs.tsx
+++ b/src/pages/Jobs.tsx
@@ -500,16 +500,8 @@ const Jobs: React.FC = (): ReactElement => {
               />
             </Box>
           )}
-          {imatView === 1 && (
-            <Box sx={{ pt: 2 }}>
-              <IMATViewer mode="latest" showNav={false} />
-            </Box>
-          )}
-          {imatView === 2 && (
-            <Box sx={{ pt: 2 }}>
-              <IMATViewer mode="stack" showNav={false} />
-            </Box>
-          )}
+          {imatView === 1 && <IMATViewer mode="latest" showNav={false} />}
+          {imatView === 2 && <IMATViewer mode="stack" showNav={false} />}
         </>
       ) : (
         <Box className="tour-red-his-tablehead" sx={{ padding: '0 20px 160px' }}>


### PR DESCRIPTION
Closes #737.

## Description

Adds:
- A responsive job tree grouped by experiment, showing successful IMAT stacks newest-first.
- Automatic selection of the newest stack when opening the viewer.
- Full-history search by experiment number or run/filename.
- “Load more” pagination for older jobs.
- URL-backed stack selection, preserving shareable deep links and browser back navigation.
- Validation and clear errors for invalid or unavailable jobs.
- Safe cancellation of stale requests when switching stacks quickly.
- Automatic image-index clamping and reset of stack-specific viewer state.